### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Only directors of the Foundation For Public Code are allowed to approve releases.
+*       @publiccodenet/directors


### PR DESCRIPTION
This file is meant to guard the ‘About’ repository against pushes that have not been okay-ed by directors.

Using the GitHub team for Directors could introduce a security risk as another admin could add themselves, then again they could also turn of branch protection completely.