### PR TITLE
Render repo files to HTML

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,8 @@ permalinks: pretty
 
 include:
   - README.md
+  - CODE_OF_CONDUCT.md
+  - CONTRIBUTING.md
 
 plugins:
   - jekyll-remote-theme


### PR DESCRIPTION
By default Jekyll doesn't render repository files as HTML, however, we might want to link to them from the website.