### PR TITLE
Activity: codebase auditing

### DIFF
--- a/activities/codebase-auditing/index.md
+++ b/activities/codebase-auditing/index.md
@@ -1,0 +1,21 @@
+# Codebase Auditing
+
+We perform audits on [codebases](../../glossary/codebase.md) – including source code, policy, documentation and conversations therein – as well as individual contribution to that codebase in order to guarantee that they are compliant with the standards set out by the Foundation For Public Code and the standards set out in the codebase itself.
+
+The audit performed by auditors of the Foundation For Public Code is meant to complement machine testing. Auditors test for whether documentation is actually understandable and attached, the commit messages make sense, community-oriented guidelines are being followed and other factors that cannot be machine tested.
+
+Certification by the Foundation For Public Code on suggested contributions can provide trust to maintainers trust when deciding whether to incorporate them.
+
+## The auditing process
+
+The audit happens completely in the version control platform and is designed to fit in to an regular Agile software developement process. When a contribution gets presented for inclusion in to the codebase a Foundation For Public Code staff auditor that knows the codebase will provide a review or certify the contribution. 
+
+The review and/or certification will happen within 2 business days to enable Agile development and not prevent users and maintainers from advancing.
+
+If a contribution passes and is certified the audit the codebase maintainers will be informed.
+
+## Public Code codebase and contribution certifications
+
+If an individual contribution to a codebase passes the audit that contribution is certified. If every contribution to a codebase has been certified – or the entire codebase has passed and been certified as one contribution – the codebase is certified.
+
+If the Public Code audit process is added to a codebase farther along in its development new merge requests can be certified, however, the existing code cannot be certified. By auditing every contribution the codebase can move towards being completely certified. For the codebase to be completely certified every meaningful line of code, and the commits behind the code, need to be up to the standards.

--- a/activities/index.md
+++ b/activities/index.md
@@ -1,37 +1,5 @@
-# Activities
+# Index of Activities
 
-## Product Stewardship
+All of the activities, products and services of the Foundation For Public Code serve to further the [Mission](../mission/index.md).
 
-We help public source code & policy code products be successful by guaranteeing their marketability and quality. Trustworthy, usable, maintained and sustainable code & code for your city.
-
-We provide the following for products, projects and codebases in our care:
-
-* IP management, product stewardship
-* Code, policy and documentation quality assurance
-* Productization services: branding, communication, refactoring for reuse
-* Community management: processing feedback and contributions, events
-* Packaging, distributing official versions, compatibility updating
-* Marketing, communications, public relations
-* Developer advocacy, user support, end-user success, training materials
-* Project infrastructure, process management
-
-### Making collaboration across contexts possible
-
-We provide these services explicitly at _ecosystem level_ – not at a national or city level – to make sure that context specific code or policy does not become a barrier to implementation.
-This means that we make sure that code is reusable across contexts globally.
-
-For local implementations we collaborate with local implementation partners, working actively with them to both integrate effectively in the local context while simultaneously making it easier for others to implement as well.
-
-### Providing long term product sustainability
-
-One of the biggest barriers to uptake of Open Source code & code is the unpredictable nature of maintainers.
-
-Products in the care of the Foundation For Public Code have long term sustainability so that prospective users can trust there will be packages when they need to update their systems and that there will be someone to receive their Pull Request after the original maintainers have moved on.
-
-We provide this sustainability in the first place by creating strong communities of users and developers that can take ownership over the product.
-
-### Giving you the agility you need
-
-Product stewardship is not someting you can stick onto a product after you've developed it, it is a continuous process. The Foundation For Public Code is agile and works asynchronous to help Pull Requests be merged, and Issues be resolved sooner.
-
-We test for code and documentation quality, as well as security issues, in every Pull Request to a shared `develop` or `release` branch to make sure that problems can be spotted as quickly as possible and there is little technical debt created. This enables for a faster collaborative development and easier publication of releases.
+* [Product Stewardship](product-stewardship/index.md): Providing for the sustainability, marketability and assured quality of a Public Code product.

--- a/activities/index.md
+++ b/activities/index.md
@@ -3,3 +3,4 @@
 All of the activities, products and services of the Foundation For Public Code serve to further the [Mission](../mission/index.md).
 
 * [Product Stewardship](product-stewardship/index.md): Providing for the sustainability, marketability and assured quality of a Public Code product.
+* [Codebase auditing](codebase-auditing/index.md): Certifying contributions and codebases as Public Code.

--- a/activities/product-stewardship/index.md
+++ b/activities/product-stewardship/index.md
@@ -1,0 +1,29 @@
+# Product Stewardship
+
+Through Product Stewardship we help public source code & policy code products become successful by guaranteeing their marketability and quality. Trustworthy, usable, maintained and sustainable code & code for your city.
+
+We provide the following for products, projects and codebases under our stewardship:
+
+* Codebase Auditing: Code, policy and documentation quality assurance
+* Community management: processing feedback and contributions, events
+* Productization services: branding, communication, refactoring for reuse
+* Packaging, distributing official versions, compatibility updating
+* Marketing, communications, public relations
+* Developer advocacy, user support, end-user success, training materials
+* Operations: Project infrastructure, process management
+* Legal services: IP management, trademark protection
+
+## Making collaboration across contexts possible
+
+We provide these services explicitly at _ecosystem level_ – not at a national or city level – to make sure that context specific code or policy does not become a barrier to implementation.
+This means that we make sure that code is reusable across contexts globally.
+
+For local implementations we collaborate with local implementation partners, working actively with them to both integrate effectively in the local context while simultaneously making it easier for others to implement as well.
+
+## Providing long term product sustainability
+
+One of the biggest barriers to uptake of Open Source code & code is the unpredictable nature of maintainers.
+
+Products in the care of the Foundation For Public Code have long term sustainability so that prospective users can trust there will be packages when they need to update their systems and that there will be someone to receive their Pull Request after the original maintainers have moved on.
+
+We provide this sustainability in the first place by creating strong communities of users and developers that can take ownership over the product.

--- a/activities/product-stewardship/index.md
+++ b/activities/product-stewardship/index.md
@@ -4,7 +4,7 @@ Through Product Stewardship we help public source code & policy code products be
 
 We provide the following for products, projects and codebases under our stewardship:
 
-* Codebase Auditing: Code, policy and documentation quality assurance
+* [Codebase Auditing](../codebase-auditing/index.md): Code, policy and documentation quality assurance
 * Community management: processing feedback and contributions, events
 * Productization services: branding, communication, refactoring for reuse
 * Packaging, distributing official versions, compatibility updating

--- a/glossary/codebase.md
+++ b/glossary/codebase.md
@@ -1,0 +1,5 @@
+# Codebase
+
+All of the code – including source code, policy, documentation and the history – of a  product. Often stored in one or multiple repositories.
+
+Codebases of the [products stewarded by the Foundation For Public Code](../activities/product-stewardship/index.md) are hosted and managed by the Foundation For Public Code.

--- a/glossary/index.md
+++ b/glossary/index.md
@@ -1,1 +1,3 @@
 # Index of glossary terms
+
+* [Codebase](codebase.md)


### PR DESCRIPTION
Taking from the 'codebase auditor' manual that we've been developing over the previous months, I've distilled what I believe is important to be in the `about`. This omits any tool specifics as those are for the manual and the marketing page.

This PR includes the `Glossary` branch.