### PR TITLE
Add the 'in founding' status to contact section

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,7 +17,9 @@ We can [really use your help](CONTRIBUTING.md) in setting up the Foundation For 
 
 ## Contact
 
-The Foundation For Public Code
+The Foundation For Public Code is currently 'in founding', which means there is no judicial entity for it whilst we make sure we can get started with the right statutes.
+
+For more information about what we're doing please reach out to us at:
 
 * [info@publiccode.net](mailto:info@publiccode.net)
 * [github.com/publiccodenet](https://github.com/publiccodenet)


### PR DESCRIPTION
Add an explanation of the organisation not existing yet, so that others who might be interested in what we're doing know what will happen if they contact us.