### PR TITLE
Add overview of roles and open positions

### DIFF
--- a/roles/community.md
+++ b/roles/community.md
@@ -1,0 +1,18 @@
+# Community Manager
+
+The Foundation For Public Code helps makers of Open Source software used to solve problems in public organizations – such as governments and cities – build communities around their Codebases so that the Codebases can become stronger, more knowledge is shared across organizations and the quality of public services improves.
+
+The Foundation For Public Code builds communities of developers, designers, policy makers, managers and other stakeholders around the Open Source codebases it has in stewardship.
+
+As a Community Manager for Codebases in our Stewardship you:
+
+* help connect members of communities
+* organise events and happenings
+* aide the development of governance of communities
+* make sure communities are healthy
+* enforce community policies such as Codes of Conduct
+* partake in the community
+
+If you enjoy connecting a wide variety of passionate technologists and stakeholders that work for the public good with meaningful interactions as well as believe in Open Source as a collaboration method, this is you.
+
+This is a full time role in our main offices in Amsterdam, The Netherlands. Relocation possible. Compensation is competitive as well as in line with the public mission of the organization.

--- a/roles/index.md
+++ b/roles/index.md
@@ -1,0 +1,21 @@
+# Staff Roles and open positions
+
+## Hiring
+
+We're looking for people to join our mission and staff for these roles, if you are interested in one of the positions below, please get in touch with us at [info@publiccode.net](mailto:info@publiccode.net).
+
+* [Quality Manager](quality.md): Help developers build high quality Public Code (Full time, Amsterdam)
+* [Community Manager](community.md): Grow strong communities around the codebases (Full time, Amsterdam)
+* [Marketing Manager](marketing.md): Make Codebases strong competitors to other solutions out there (Full time, Amsterdam)
+* [Support Manager](support.md): Provide answers to questions about usage, contributing, procurement and more (Full time, Amsterdam)
+
+## Not hiring
+
+We're currently not looking for these roles, however if you think you fit in to our organization in a way we don't understand yet, please get in touch.
+
+* Chief Executive
+* Deputy Chief Executive (secretariat, process management, research and on-boarding)
+* Chief Member and Partner Relations (Fundraising, Member growth, Partner growth, Communications)
+* Head of Resources (Physical, Human and Financial)
+* Head of Security and Threats (Physical, Organizational and Digital)
+* Head of Legal (IP, Organisation, Licence and Contracts)

--- a/roles/marketing.md
+++ b/roles/marketing.md
@@ -1,0 +1,17 @@
+# Marketing Manager
+
+The Foundation For Public Code helps public organizations – such as governments and cities – collaborate on solving their problems by developing Open Source solutions which when reused will become better quality, more cost effective, more resilient and attract more contributors.
+
+In order to get larger uptake for these Codebases – that often compete with closed source software products – policy makers, management and developers in public organizations need to get to know the Codebases and how to use them to solve their problems.
+
+As a Marketing Manager for Codebases in our Stewardship you:
+
+* make the Codebase into a product
+* provide branding for Codebases that they stand out from other – often proprietary – solutions
+* build the communications channels necessary for getting the word out
+* work to build a market for the Codebase and the solution it provides
+* help others sell the Codebase to their management, coworkers or clients
+* create a buzz around the Codebase
+* partake in the community
+
+This is a full time role in our main offices in Amsterdam, The Netherlands. Relocation possible. Compensation is competitive as well as in line with the public mission of the organization.

--- a/roles/quality.md
+++ b/roles/quality.md
@@ -1,0 +1,15 @@
+# Quality Manager
+
+The Foundation For Public Code helps developers of Open Source software used for public uses – such as in governments and cities – make their codebases high quality so that they are understandable, well documented, easy to work with and highly reusable.
+
+We provide review of contributions to Codebases that are in Codebase Stewardship at the Foundation For Public Code in order to help developers build trusted and reliable software that can be widely reused and can foster a strong community. We test against the quality Public Code standards for code and documentation we set which aim to make Codebases understandable, reusable and community based. Our standards are high as well as opinionated to give trust the code can really serve as the infrastructure of society as well as continually improving with the changing world whilst keeping the choices of technology and architecture open.
+
+As a Quality Manager for Codebases in our Stewardship you:
+
+* reviewing pull requests and giving feedback on the reusability, documentation and integrity of the codebase
+* updating the standards for quality Public Code that we use to test for
+* partake in the community
+
+If you enjoy working together with a wide array of developers to make Open Source codebases really shine as well as improve the role of technology in society, this is you.
+
+This is a full time role in our main offices in Amsterdam, The Netherlands. Relocation possible. Compensation is competitive as well as in line with the public mission of the organization.

--- a/roles/support.md
+++ b/roles/support.md
@@ -1,0 +1,17 @@
+# Support Manager
+
+The Foundation For Public Code helps public organizations – such as governments and cities – collaborate on solving their problems by developing Open Source solutions which when reused will become better quality, more cost effective, more resilient and attract more contributors.
+
+For the public organizations that would benefit from using, or contributing to, these Codebases it might not always be easy to get started, know how to use or procure a solution like this or to trust in the Codebase.
+
+As a Support Manager for Codebases in our Stewardship you:
+
+* help potential users find out how to use codebases
+* provide assistance in procuring solutions based on codebases
+* resolve issues in sales of solutions based on codebases
+* connect potential users to potential (trusted) vendors of solutions
+* provide a contact point for issues surrounding a codebase
+* provide support for the community around a Codebase to answer these questions themselves
+* partake in the community
+
+This is a full time role in our main offices in Amsterdam, The Netherlands. Relocation possible. Compensation is competitive as well as in line with the public mission of the organization.


### PR DESCRIPTION
I've added Job descriptions for the open positions in our organisation as well as a section (folder) where we can add a description for every role in our organisation.

The main points I would like feedback on are:

* Descriptions of the roles
* The 'what you'll do' sections
* And the job titles

These jobs will work in one team and will always work together with all these roles on every project, so thinking out how they fit into that together is I think important.

In my current thinking they are the 'Codebase Management' team of a single Codebase (but can be on multiple).