### PR TITLE
Add breadcrumbs for Activities, Roles and Glossary

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: About the Foundation For Public Code
+title: About the Foundation For Public Code
 permalinks: pretty
 
 include:
@@ -17,3 +17,26 @@ exclude:
 
 # Display Table of Contents on every page, disable by adding `toc: false` to the front matter of any file
 toc: true
+
+defaults:
+  -
+    scope: 
+      path: '/glossary/[!index]*'
+    values:
+      breadcrumbs:
+        - name: 'Glossary'
+          path: '/glossary/'
+  -
+    scope: 
+      path: '/roles/[!index]*'
+    values:
+      breadcrumbs:
+        - name: 'Roles'
+          path: '/roles/'
+  -
+    scope: 
+      path: '/activities/[!index]*'
+    values:
+      breadcrumbs:
+        - name: 'Activities'
+          path: '/activities/'


### PR DESCRIPTION
Just a stop-gap solution to allow for a bit more navigation in the About site.

<img width="953" alt="Screenshot 2019-03-14 at 13 48 54" src="https://user-images.githubusercontent.com/1917629/54358197-0703b900-4660-11e9-8ec7-e040751f6090.png">
