### PR TITLE
Lowercasing for in Foundation (#106)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# Only directors of the Foundation For Public Code are allowed to approve releases.
+# Only directors of the Foundation for Public Code are allowed to approve releases.
 *       @publiccodenet/directors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Contributor Guide 🙇‍
 
-The Foundation For Public Code has [a mission to develop an Open Source ecosystem for cities](mission/index.md). In order to fulfill our mission we – the directors of the Foundation, our advisors and contributors – need your help!
+The Foundation for Public Code has [a mission to develop an Open Source ecosystem for cities](mission/index.md). In order to fulfill our mission we – the directors of the Foundation, our advisors and contributors – need your help!
 
-This repository serves as the 'official source of truth' about the Foundation For Public Code. It contains all of its documentation, procedures and information as well as explanations on what the Foundation For Public Code does. We see it a bit like a 'living' charter.
+This repository serves as the 'official source of truth' about the Foundation for Public Code. It contains all of its documentation, procedures and information as well as explanations on what the Foundation for Public Code does. We see it a bit like a 'living' charter.
 
-In this guide we try to set out all the ways you can contribute to the Foundation For Public Code.
+In this guide we try to set out all the ways you can contribute to the Foundation for Public Code.
 
 ## How you can help
 
@@ -45,7 +45,7 @@ And of course we'd love input into our projects as well, like [`publiccode.yml`]
 
 ## Becoming an advisor
 
-If you provide us with meaningful contributions we might ask you to become an advisor. Our advisors are a group of subject matter experts from different fields that help us to progress the mission of the Foundation For Public Code and have a special position within the Foudation.
+If you provide us with meaningful contributions we might ask you to become an advisor. Our advisors are a group of subject matter experts from different fields that help us to progress the mission of the Foundation for Public Code and have a special position within the Foudation.
 
 ## Responsible disclosure and contact information
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # Content Governance
 
-This project represents the Foundation For Public Code. Therefore any changes adopted into the `master` branch have to be accepted by the directors of the Foundation For Public Code. The `sprint` branch contains all features approved by at least one director and it represents the current 'working draft' version of the Foundation.
+This project represents the Foundation for Public Code. Therefore any changes adopted into the `master` branch have to be accepted by the directors of the Foundation for Public Code. The `sprint` branch contains all features approved by at least one director and it represents the current 'working draft' version of the Foundation.
 
 ## New content and changes into the `sprint` branch
 
@@ -8,4 +8,4 @@ Every change and new feature can be accepted into the `develop` branch by any di
 
 ## Publishing the changes from `sprint` to `master`
 
-All of the changes in `develop` are agreed upon in by all directors of the Foundation For Public Code before they can be merged and are accepted as 'truth'. This usally happens in the weekly directors meeting.
+All of the changes in `develop` are agreed upon in by all directors of the Foundation for Public Code before they can be merged and are accepted as 'truth'. This usally happens in the weekly directors meeting.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# About the Foundation For Public Code
+# About the Foundation for Public Code
 
 [From our mission](mission/index.md):
 
 > [...] We aim to maintain, manage, contribute to and grow an ecosystem of public software and policies that help governments, communities and citizens improve their city.
 
-This repository is meant to reflect the concept of the Foundation For Public Code and hold all information about it.
-It's `master` branch is the official ['source of truth'](GOVERNANCE.md) and central repository for all information about the Foundation For Public Code.
+This repository is meant to reflect the concept of the Foundation for Public Code and hold all information about it.
+It's `master` branch is the official ['source of truth'](GOVERNANCE.md) and central repository for all information about the Foundation for Public Code.
 
 ## Contributing
 
-We are looking for people like you to [contribute](CONTRIBUTING.md) to this project by suggesting improvements and helping develop the Foundation For Public Code. 😊 Get started by reading our [Contributors Guide](CONTRIBUTING.md).
+We are looking for people like you to [contribute](CONTRIBUTING.md) to this project by suggesting improvements and helping develop the Foundation for Public Code. 😊 Get started by reading our [Contributors Guide](CONTRIBUTING.md).
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms. Please be lovely to all other community members.
 
@@ -32,6 +32,6 @@ All branches are tested with every change for broken links, so if some site we l
 
 [![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
 
-To the extent possible under law, the Foundation For Public Code has waived all copyright and related or neighboring rights to the content in this repository. It is [licensed CCO](https://creativecommons.org/publicdomain/zero/1.0/), which basically means that anyone can do anything with it. This does not apply to trademarks or logos of the Foundation For Public Code.
+To the extent possible under law, the Foundation for Public Code has waived all copyright and related or neighboring rights to the content in this repository. It is [licensed CCO](https://creativecommons.org/publicdomain/zero/1.0/), which basically means that anyone can do anything with it. This does not apply to trademarks or logos of the Foundation for Public Code.
 
 Contributors to this repository agree that their contributions also fall under this license and that they have the power and authority to grant this licence.

--- a/activities/codebase-auditing/index.md
+++ b/activities/codebase-auditing/index.md
@@ -1,14 +1,14 @@
 # Codebase Auditing
 
-We perform audits on [codebases](../../glossary/codebase.md) – including source code, policy, documentation and conversations therein – as well as individual contribution to that codebase in order to guarantee that they are compliant with the standards set out by the Foundation For Public Code and the standards set out in the codebase itself.
+We perform audits on [codebases](../../glossary/codebase.md) – including source code, policy, documentation and conversations therein – as well as individual contribution to that codebase in order to guarantee that they are compliant with the standards set out by the Foundation for Public Code and the standards set out in the codebase itself.
 
-The audit performed by auditors of the Foundation For Public Code is meant to complement machine testing. Auditors test for whether documentation is actually understandable and attached, the commit messages make sense, community-oriented guidelines are being followed and other factors that cannot be machine tested.
+The audit performed by auditors of the Foundation for Public Code is meant to complement machine testing. Auditors test for whether documentation is actually understandable and attached, the commit messages make sense, community-oriented guidelines are being followed and other factors that cannot be machine tested.
 
-Certification by the Foundation For Public Code on suggested contributions can provide trust to maintainers trust when deciding whether to incorporate them.
+Certification by the Foundation for Public Code on suggested contributions can provide trust to maintainers trust when deciding whether to incorporate them.
 
 ## The auditing process
 
-The audit happens completely in the version control platform and is designed to fit in to an regular Agile software developement process. When a contribution gets presented for inclusion in to the codebase a Foundation For Public Code staff auditor that knows the codebase will provide a review or certify the contribution. 
+The audit happens completely in the version control platform and is designed to fit in to an regular Agile software developement process. When a contribution gets presented for inclusion in to the codebase a Foundation for Public Code staff auditor that knows the codebase will provide a review or certify the contribution. 
 
 The review and/or certification will happen within 2 business days to enable Agile development and not prevent users and maintainers from advancing.
 

--- a/activities/codebase-stewardship/index.md
+++ b/activities/codebase-stewardship/index.md
@@ -24,6 +24,6 @@ For local implementations we collaborate with local implementation partners, wor
 
 One of the biggest barriers to uptake of Open Source code & code is the unpredictable nature of maintainers.
 
-Products in the care of the Foundation For Public Code have long term sustainability so that prospective users can trust there will be packages when they need to update their systems and that there will be someone to receive their Pull Request after the original maintainers have moved on.
+Products in the care of the Foundation for Public Code have long term sustainability so that prospective users can trust there will be packages when they need to update their systems and that there will be someone to receive their Pull Request after the original maintainers have moved on.
 
 We provide this sustainability in the first place by creating strong communities of users and developers that can take ownership over the product.

--- a/activities/index.md
+++ b/activities/index.md
@@ -1,6 +1,6 @@
 # Index of Activities
 
-All of the activities, products and services of the Foundation For Public Code serve to further the [Mission](../mission/index.md).
+All of the activities, products and services of the Foundation for Public Code serve to further the [Mission](../mission/index.md).
 
 * [Codebase Stewardship](codebase-stewardship/index.md): Providing for the sustainability, marketability and assured quality of a Public Code product.
 * [Codebase auditing](codebase-auditing/index.md): Certifying contributions and codebases as Public Code.

--- a/glossary/codebase.md
+++ b/glossary/codebase.md
@@ -4,4 +4,4 @@ Any discreet package of Code – both source and policy – tests and documentat
 
 This can be – for example – a document or a version-control repository.
 
-Codebases of the [products Stewarded by the Foundation For Public Code](../activities/codebase-stewardship/index.md) are hosted and managed by the Foundation For Public Code.
+Codebases of the [products Stewarded by the Foundation for Public Code](../activities/codebase-stewardship/index.md) are hosted and managed by the Foundation for Public Code.

--- a/glossary/staff.md
+++ b/glossary/staff.md
@@ -1,0 +1,3 @@
+# Staff
+
+Someone employed directly by the Foundation For Public Code. This excludes community members, volunteers and freelancers.

--- a/index.md
+++ b/index.md
@@ -16,11 +16,11 @@ Additionally we have seperate sites that show our [projects](https://projects.pu
 
 ## We need you
 
-We can [really use your help](CONTRIBUTING.md) in setting up the Foundation For Public Code and making it successful.
+We can [really use your help](CONTRIBUTING.md) in setting up the Foundation for Public Code and making it successful.
 
 ## Contact
 
-The Foundation For Public Code is currently 'in founding', which means there is no judicial entity for it whilst we make sure we can get started with the right statutes.
+The Foundation for Public Code is currently 'in founding', which means there is no judicial entity for it whilst we make sure we can get started with the right statutes.
 
 For more information about what we're doing please reach out to us at:
 

--- a/mission/index.md
+++ b/mission/index.md
@@ -1,4 +1,4 @@
-# Mission of the Foundation For Public Code
+# Mission of the Foundation for Public Code
 
 We create a viable future for cities and civic operating systems that are highly participatory and drive societal engagement. A public digital infrastructure that is inclusive, usable, adaptive, open and sustainable.
 

--- a/roles/community.md
+++ b/roles/community.md
@@ -1,6 +1,6 @@
 # Codebase Steward, Community
 
-The Foundation For Public Code helps the makers of Open Source software for public use – such as governments and cities – build communities around their [Codebases](../glossary/codebase.md) so that knowledge is shared across organizations, Codebases can become stronger, and the quality of public services improve.
+The Foundation for Public Code helps the makers of Open Source software for public use – such as governments and cities – build communities around their [Codebases](../glossary/codebase.md) so that knowledge is shared across organizations, Codebases can become stronger, and the quality of public services improve.
 
 We build communities of developers, designers, policy makers, managers and other stakeholders around the Open Source codebases it has in its Stewardship.
 

--- a/roles/product-marketing.md
+++ b/roles/product-marketing.md
@@ -1,6 +1,6 @@
 # Codebase Steward, Product Marketing
 
-The Foundation For Public Code helps public organizations – such as governments and cities – collaborate on solving their problems by developing Open Source solutions which, when reused, become more cost effective, of a higher quality, more resilient, and more attractive to contributors.
+The Foundation for Public Code helps public organizations – such as governments and cities – collaborate on solving their problems by developing Open Source solutions which, when reused, become more cost effective, of a higher quality, more resilient, and more attractive to contributors.
 
 In order to get a wider uptake for these Codebases – that often compete with closed source software products – policy makers, management and developers in public organizations need to get to know the [Codebases](../glossary/codebase.md) and how to use them to solve their problems.
 As a Codebase Steward, Product Marketing you help:

--- a/roles/quality.md
+++ b/roles/quality.md
@@ -1,8 +1,8 @@
 # Codebase Steward, Quality
 
-The Foundation For Public Code helps the developers of Open Source software for public use – such as in governments and cities – improve the quality of their [Codebases](../glossary/codebase.md) by making them easier to understand, well documented, and thus highly reusable. 
+The Foundation for Public Code helps the developers of Open Source software for public use – such as in governments and cities – improve the quality of their [Codebases](../glossary/codebase.md) by making them easier to understand, well documented, and thus highly reusable. 
 
-We provide review of contributions to Codebases that are in Codebase Stewardship at the Foundation For Public Code in order to help developers build trusted and reliable software that can be widely reused and can foster a strong community. We test against the quality Public Code standards for code and documentation we set which aim to make Codebases understandable, reusable and community based. Our standards are high, as well as opinionated, to ensure Codebases can be trusted as the infrastructure of society, improve continually, and keep technology and architectural choices open.
+We provide review of contributions to Codebases that are in Codebase Stewardship at the Foundation for Public Code in order to help developers build trusted and reliable software that can be widely reused and can foster a strong community. We test against the quality Public Code standards for code and documentation we set which aim to make Codebases understandable, reusable and community based. Our standards are high, as well as opinionated, to ensure Codebases can be trusted as the infrastructure of society, improve continually, and keep technology and architectural choices open.
 
 As a Codebase Steward, Quality you help:
 

--- a/roles/support.md
+++ b/roles/support.md
@@ -1,6 +1,6 @@
 # Codebase Steward, Support
 
-The Foundation For Public Code helps public organizations – such as governments and cities – collaborate on solving their problems by developing Open Source solutions which, when reused, become more cost effective, of a higher quality, more resilient and attract more contributors.
+The Foundation for Public Code helps public organizations – such as governments and cities – collaborate on solving their problems by developing Open Source solutions which, when reused, become more cost effective, of a higher quality, more resilient and attract more contributors.
 
 For the public organizations that would benefit from using, or contributing to, these [Codebases](../glossary/codebase.md) it might not always be easy to get started, know how to use or procure a solution like this or to trust in the Codebase.
 


### PR DESCRIPTION
We decided that the for in Foundation for Public Code should be lowercase. We're going through and changing it everywhere.