### PR TITLE
Move product marketing codebase steward role

### DIFF
--- a/roles/index.md
+++ b/roles/index.md
@@ -4,9 +4,8 @@
 
 We're looking for people to join our mission and staff for these roles, if you are interested in one of the positions below, please get in touch with us at [info@publiccode.net](mailto:info@publiccode.net).
 
-* [Codebase Steward, Quality](quality.md): Help developers build high quality Public Code (Full time, Amsterdam)
+* [Codebase Steward, Quality](quality.md): Help developers build high quality public code (Full time, Amsterdam)
 * [Codebase Steward, Community](community.md): Grow strong communities around the codebases (Full time, Amsterdam)
-* [Codebase Steward, Product Marketing](product-marketing.md): Make Codebases strong competitors to other solutions out there (Full time, Amsterdam)
 * [Codebase Steward, Support](support.md): Provide answers to questions about usage, contributing, procurement and more (Full time, Amsterdam)
 
 ## Not hiring
@@ -15,3 +14,4 @@ We're currently not looking for these roles, however if you think you fit in to 
 
 * Chief Executive
 * Chief Operating
+* [Codebase Steward, Product Marketing](product-marketing.md): Make codebases strong competitors to other solutions out there


### PR DESCRIPTION
Moved to 'not currently recruiting'