### PR TITLE
Added the GitHub labs courses

### DIFF
--- a/activities/trainings/github-for-newcomers.md
+++ b/activities/trainings/github-for-newcomers.md
@@ -1,5 +1,7 @@
 # GitHub for newcomers
 
+This guide explains: How to learn to use GitHub effectively for working with the Foundation for Public Code projects.
+
 GitHub is an incredibly powerful tool for collaboration at scale. However it is a power-tool and requires some serious learning and understanding. For this reason, in order to learn effectively and not be frustrated often it pays to really dive deep into what it is and how it works.
 
 If you know what a rebase is, this guide is not for you. If you don't we expect you to know and understand everything that is in these courses.
@@ -10,11 +12,11 @@ The GitHub labs courses
 
 For our way of working and how we use GitHub following this order makes sense:
 
-* [Introduction to GitHub](https://lab.github.com/githubtraining/introduction-to-github)
-* [Communicating using MarkDown](https://lab.github.com/githubtraining/communicating-using-markdown)
+* [Introduction to GitHub](https://lab.github.com/githubtraining/introduction-to-github).
+* [Communicating using MarkDown](https://lab.github.com/githubtraining/communicating-using-markdown).
 * [GitHub pages](https://lab.github.com/githubtraining/github-pages)
-* [Reviewing pull requests](https://lab.github.com/githubtraining/reviewing-pull-requests)
-* [Managing merge conflicts](https://lab.github.com/githubtraining/managing-merge-conflicts)
+* [Reviewing pull requests](https://lab.github.com/githubtraining/reviewing-pull-requests).
+* [Managing merge conflicts](https://lab.github.com/githubtraining/managing-merge-conflicts).
 
 Tip: If you get stuck because you think the bot should respond but it doesn't it often helps to refresh the page.
 

--- a/activities/trainings/github-for-newcomers.md
+++ b/activities/trainings/github-for-newcomers.md
@@ -12,11 +12,11 @@ The GitHub labs courses
 
 For our way of working and how we use GitHub following this order makes sense:
 
-* [Introduction to GitHub](https://lab.github.com/githubtraining/introduction-to-github).
-* [Communicating using MarkDown](https://lab.github.com/githubtraining/communicating-using-markdown).
-* [GitHub pages](https://lab.github.com/githubtraining/github-pages)
-* [Reviewing pull requests](https://lab.github.com/githubtraining/reviewing-pull-requests).
-* [Managing merge conflicts](https://lab.github.com/githubtraining/managing-merge-conflicts).
+1. [Introduction to GitHub](https://lab.github.com/githubtraining/introduction-to-github).
+2. [Communicating using MarkDown](https://lab.github.com/githubtraining/communicating-using-markdown).
+3. [GitHub pages](https://lab.github.com/githubtraining/github-pages)
+4. [Reviewing pull requests](https://lab.github.com/githubtraining/reviewing-pull-requests).
+5. [Managing merge conflicts](https://lab.github.com/githubtraining/managing-merge-conflicts).
 
 Tip: If you get stuck because you think the bot should respond but it doesn't it often helps to refresh the page.
 

--- a/activities/trainings/github-for-newcomers.md
+++ b/activities/trainings/github-for-newcomers.md
@@ -1,0 +1,27 @@
+# GitHub for newcomers
+
+GitHub is an incredibly powerful tool for collaboration at scale. However it is a power-tool and requires some serious learning and understanding. For this reason, in order to learn effectively and not be frustrated often it pays to really dive deep into what it is and how it works.
+
+If you know what a rebase is, this guide is not for you. If you don't we expect you to know and understand everything that is in these courses.
+
+## Do it yourself, guided
+
+The GitHub labs courses
+
+For our way of working and how we use GitHub following this order makes sense:
+
+* [Introduction to GitHub](https://lab.github.com/githubtraining/introduction-to-github)
+* [Communicating using MarkDown](https://lab.github.com/githubtraining/communicating-using-markdown)
+* [GitHub pages](https://lab.github.com/githubtraining/github-pages)
+* [Reviewing pull requests](https://lab.github.com/githubtraining/reviewing-pull-requests)
+* [Managing merge conflicts](https://lab.github.com/githubtraining/managing-merge-conflicts)
+
+Tip: If you get stuck because you think the bot should respond but it doesn't it often helps to refresh the page.
+
+With this knowledge you should now be good to go with your GitHub use!
+
+## Further learning
+
+If you want someone to show you:
+
+* [Git and GitHub for poets](https://www.youtube.com/playlist?list=PLRqwX-V7Uu6ZF9C0YMKuns9sLDzK6zoiV) (10 minute episodes, in total about 2 hours)

--- a/activities/trainings/github-for-newcomers.md
+++ b/activities/trainings/github-for-newcomers.md
@@ -27,3 +27,4 @@ With this knowledge you should now be good to go with your GitHub use!
 If you want someone to show you:
 
 * [Git and GitHub for poets](https://www.youtube.com/playlist?list=PLRqwX-V7Uu6ZF9C0YMKuns9sLDzK6zoiV) (10 minute episodes, in total about 2 hours)
+* [GitHub's Guides YouTube channel](https://www.youtube.com/githubguides)

--- a/activities/trainings/github-for-newcomers.md
+++ b/activities/trainings/github-for-newcomers.md
@@ -2,9 +2,9 @@
 
 This guide explains: How to learn to use GitHub effectively for working with the Foundation for Public Code projects.
 
-GitHub is an incredibly powerful tool for collaboration at scale. However it is a power-tool and requires some serious learning and understanding. For this reason, in order to learn effectively and not be frustrated often it pays to really dive deep into what it is and how it works.
+GitHub is an incredibly powerful tool for collaboration at scale. However it is a power tool and requires some serious learning and understanding. For this reason, in order to learn effectively and not be frustrated often it pays to really dive deep into what it is and how it works.
 
-If you know what a rebase is, this guide is not for you. If you don't we expect you to know and understand everything that is in these courses.
+If you know what a rebase is, this guide is not for you. If you don't, we expect you to know and understand everything that is in these courses.
 
 ## Do it yourself, guided
 

--- a/activities/trainings/github-for-newcomers.md
+++ b/activities/trainings/github-for-newcomers.md
@@ -8,7 +8,7 @@ If you know what a rebase is, this guide is not for you. If you don't we expect 
 
 ## Do it yourself, guided
 
-The GitHub labs courses
+The GitHub labs courses are great courses, so it pays to read them completely as well as watch all the videos.
 
 For our way of working and how we use GitHub following this order makes sense:
 


### PR DESCRIPTION
fixes #132

I've tried a whole bunch of different trainings and have found out that the GitHub labs trainings are actually the most effective ones out there explaining both the technical as well as social aspects of using GitHub.

Please follow the guides and review this pull request with anything you find that is missing.

You can view the file here: https://github.com/publiccodenet/about/blob/github-for-newcomers/activities/trainings/github-for-newcomers.md