### PR TITLE
add team member as option to join & headers singular

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,13 +17,17 @@ We plan to scale in 2020.
 
 In the meantime, please join us in any way you can.
 
-## Individual contributors
+## Team member
+
+Our [roles page](https://about.publiccode.net/roles/) has an overview of our current job openings. If you are the person fitting one of these roles, or you know of someone who might, we'd love to hear from you.
+
+## Individual contributor
 
 Our [contributor guide for individuals](contributor-guides/for-individuals.md) explains how to find out what we’re currently working on and what we’re looking for help with.
 
 We’re especially interested in learning what you need to implement the [Standard for Public Code](http://standard.publiccode.net/) in your organization. Please [raise an issue](http://standard.publiccode.net/CONTRIBUTING.html) or email us at <info@publiccode.net>.
 
-## Public organizations
+## Public organization
 
 We’re currently looking for innovative public organizations to [join us as founding members](http://publiccode.net/membership/founding-membership). As a founding member, you’ll have the chance to shape the Foundation’s processes and governance. Your code will be among the first accepted for Foundation stewardship.
 


### PR DESCRIPTION
i think that site visitors with an interest in working with us, will click on 'join' and then expect to find text on who you can join the org as a team member.