### PR TITLE
proofread page: Founding membership proposal template

### DIFF
--- a/activities/member-relations/founding-membership-proposal.md
+++ b/activities/member-relations/founding-membership-proposal.md
@@ -2,20 +2,20 @@
 type: Resource
 ---
 
-# Founding Membership Proposal template
+# Founding membership proposal template
 
-## Goal: 
-This document serves as a draft proposal to send to public organizations that are exploring  joining the Foundation for Public Code as a Founding Member. It serves to formalise our conversation with them, and work out the next steps and a timeline together with them.
+## Goal
+This document serves as a draft proposal to send to public organizations that are exploring joining the Foundation for Public Code as a founding member. It serves to formalize our conversation, and work out the next steps and a timeline together.
 
-## Resource: 
-You can access the template here: https://docs.google.com/document/d/1icscB-9jPUF2psL1pm8mM_53BKQ5gEIKqmHnsTicKKY/edit?usp=sharing
+## Resource
+You can access the template here: <https://docs.google.com/document/d/1icscB-9jPUF2psL1pm8mM_53BKQ5gEIKqmHnsTicKKY/edit?usp=sharing>
 
-## Assumptions:
-* Our strategy is to work with our contacts within the organization to make a convincing proposal to their highest level of political decision making
-* We first send them this draft full proposal, which invites them to sign a light-weight/low-commitment Expression of Interest. This means we can talk about our working with them in the open, while continuing to tailor the details of this proposal
+## Assumptions
+* Our strategy is to work with our contacts within the organization to make a convincing proposal to their relevant level of political decision-making
+* We first send potential founding members this draft full proposal, which invites them to sign a light-weight/low-commitment Expression of Interest. This means we can talk about our working with them in the open, while continuing to tailor the details of this proposal
 * This resource is a link to a google doc for now, but might change format soon 
 * Any changes to the content of this template must first be made in About before being propagated into this document
 
-### Use and Further Development:
+### Use and further development
 - [ ] Share with potential members
-- [ ] Revise template with feedback once shared with 2-3 potential members
+- [ ] Revise template with feedback once shared with 2-3 potential founding members


### PR DESCRIPTION
space, colons, caps out; link in; highest>relevant; less 'othering' of the potential founding members