### PR TITLE
search 'services' and manual replace

### DIFF
--- a/activities/codebase-stewardship/index.md
+++ b/activities/codebase-stewardship/index.md
@@ -12,16 +12,16 @@ We provide the following for products, projects and codebases under our stewards
 
 * [Codebase auditing](../codebase-auditing/index.md): code, policy and documentation quality assurance
 * Community management: processing feedback and contributions, events
-* Productization services: branding, communication, refactoring for reuse
+* Productization: branding, communication, refactoring for reuse
 * Packaging, distributing official versions, compatibility updating
 * Marketing, communications, public relations
 * Developer advocacy, user support, end-user success, training materials
 * Operations: project infrastructure, process management
-* Legal services: intellectual property management, trademark protection
+* Legal: intellectual property management, trademark protection
 
 ## Making collaboration across contexts possible
 
-We provide these services explicitly at _ecosystem level_ – not at a national or city level – to make sure that context specific code or policy does not become a barrier to implementation.
+We provide these activities explicitly at _ecosystem level_ – not at a national or city level – to make sure that context specific code or policy does not become a barrier to implementation.
 This means that we make sure that code is reusable across contexts globally.
 
 For local implementations we collaborate with local implementation partners, working actively with them to both integrate effectively in the local context while simultaneously making it easier for others to implement as well.

--- a/activities/documentation/about-folder-structure.md
+++ b/activities/documentation/about-folder-structure.md
@@ -6,7 +6,7 @@ type: Resource
 
 About has a folder structure that serves as a basic skeleton for our information.
 
-* `activities`: All of our activities, processes and services such as codebase stewardship and budgeting.
+* `activities`: All of our activities and processes such as codebase stewardship and budgeting.
   * Inside of activities there is one folder per activity with its own index, resources and guides
 * `contributor-guides`: Explains how each user type can contribute. For example designers, developers or policy people.
 * `glossary`: The controlled terms we have a shared definition for.

--- a/activities/index.md
+++ b/activities/index.md
@@ -4,12 +4,12 @@ type: Index
 
 # Activities
 
-These are all of the activities, products and services of the Foundation for Public Code that serve to further the [mission](../organization/mission.md) to serve our members directly:
+These are all of the activities and products of the Foundation for Public Code that serve to further the [mission](../organization/mission.md) to serve our members directly:
 
 * [Codebase stewardship](codebase-stewardship/index.md): Providing for the sustainability, marketability and assured quality of a public code product.
 * [Codebase auditing](codebase-auditing/index.md): Certifying contributions and codebases as public code.
 
-These are the processes and services that make our operations work:
+These are the processes, activities and products that make our operations work:
 
 * [Communication](communication/index.md)
 * [Documentation of the organization](documentation/index.md)

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ The documentation of our work here on [About](activities/documentation/index.md)
 
 Read more about:
 
-* [our activities and services](activities/index.md) (starting summer 2019)
+* [our activities](activities/index.md) (starting summer 2019)
 * [our organization](organization/index.md)
 * [our roles and open positions](roles/index.md)
 * [glossary of terms and concepts](glossary/index.md)

--- a/organization/cultural-values.md
+++ b/organization/cultural-values.md
@@ -4,7 +4,7 @@ type: Resource
 
 # Cultural values
 
-These words signify the qualities we strive for in our services, products, staff and resources:
+These words signify the qualities we strive for in our activities, products, staff and resources:
 * Open
 * Quality
 * Trust


### PR DESCRIPTION
fixes #165 

Did: 
* Search for 'service' and manual replace to mostly 'activities' and sometimes 'products' where appropriate
* All remaining instances of service all refer to government/citizen services