### PR TITLE
remove special reference to cities

### DIFF
--- a/organization/goals.md
+++ b/organization/goals.md
@@ -5,6 +5,6 @@ type: Resource
 # Goals 
 
 * Enable an **ecosystem of Public Code software products**, developed by and for public administrations to solve real problems for citizens
-* Build a **collaborative community of developers and cities**, which continuously improves and maintains Public Code products 
+* Build a **collaborative community of developers and public organizations**, which continuously improves and maintains Public Code products 
 * Provide a **certification system for software** as meeting the standard set by the Foundation For Public Code
 * Build a **trusted brand and an awareness of the value of Public Code**

--- a/roles/quality.md
+++ b/roles/quality.md
@@ -4,7 +4,7 @@ type: Resource
 
 # Codebase steward for quality
 
-Come help producers of open source software for public use – such as in cities and other public organizations – improve the quality of their [codebases](../glossary/codebase-definition.md) by making them easier to understand, well documented and thus highly reusable.
+Come help producers of open source software for public use – such as governments and cities – improve the quality of their [codebases](../glossary/codebase-definition.md) by making them easier to understand, well documented and thus highly reusable.
 
 [The Foundation for Public Code](https://publiccode.net) helps public organizations develop and maintain software and policy together. We provide review of codebases that are in our stewardship to help developers build trusted and reliable software that can be widely reused and foster a strong community around it.
 


### PR DESCRIPTION
Went through and removed two solo-city references. Cities is still used in several instances as an example (`such as governments and cities`). I feel this is ok, but we could diversify. 