### PR TITLE
Rename organisation index to not duplicate homepage title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,32 +18,5 @@ exclude:
 # Display Table of Contents on every page, disable by adding `toc: false` to the front matter of any file
 toc: true
 
-defaults:
-  -
-    scope: 
-      path: '/roles/*'
-    values:
-      breadcrumbs:
-        - name: 'Roles'
-          path: '/roles/'
-  -
-    scope: 
-      path: '/activities/*'
-    values:
-      breadcrumbs:
-        - name: 'Activities'
-          path: '/activities/'
-  -
-    scope: 
-      path: '/glossary/*'
-    values:
-      breadcrumbs:
-        - name: 'Glossary'
-          path: '/glossary/'
-  -
-    scope: 
-      path: '/contributor-guides/*'
-    values:
-      breadcrumbs:
-        - name: 'Contributor guides'
-          path: '/contributor-guides/'
+# show_navigation: true
+show_breadcrumbs: true

--- a/activities/communication/index.md
+++ b/activities/communication/index.md
@@ -6,4 +6,4 @@ type: Index
 
 These are all the activities, documents and templates for Communication
 
-* [Communication Principles](communication-principles.md)
+* [Communication principles](communication-principles.md)

--- a/activities/communication/index.md
+++ b/activities/communication/index.md
@@ -2,6 +2,8 @@
 type: Index
 ---
 
+# Communication
+
 These are all the activities, documents and templates for Communication
 
 * [Communication Principles](communication-principles.md)

--- a/activities/trainings/index.md
+++ b/activities/trainings/index.md
@@ -2,6 +2,8 @@
 type: Index
 ---
 
+# Trainings
+
 Here is a list of trainings developed or used by the Foundation for Public Code:
 
 * [GitHub for newcomers](github-for-newcomers.md)

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 type: Index
 ---
 
-# What we do
+# About us
 
 We help open source projects for public organizations (like cities) become successful, build sustainable communities around them and create a thriving public open source ecosystem.
 

--- a/organization/index.md
+++ b/organization/index.md
@@ -2,7 +2,7 @@
 type: Index
 ---
 
-# About the organization
+# The organization
 
 The Foundation for Public Code's mission is to enable public-purpose software and policy that is open and collaborative. Read more about [our goals and founding principles](mission.md).
 


### PR DESCRIPTION
I've made some changes to enable the new breadcrumbs, added titles where they were missing and changes some titles in order to be more meaningful in a breadcrumb trail.