### PR TITLE
Update support and product marketing steward job descriptions to our new template

### DIFF
--- a/activities/recruitment/job-description.md
+++ b/activities/recruitment/job-description.md
@@ -24,6 +24,7 @@ As a [Job title] you work together with the community to [bespoke text]. This me
 ### What we expect from all of our team members
 
 You should:
+
 * share our core values: openness, quality, trust, community, helpfulness
 * understand the value of and be experienced with open source products and communities
 * want to work for the public good

--- a/roles/index.md
+++ b/roles/index.md
@@ -10,7 +10,7 @@ We're looking for brilliant people to join our mission. We're currently hiring f
 
 * [Codebase steward for quality](quality.md): Help developers build high quality public code (Full time, Amsterdam)
 * [Codebase steward for community](community.md): Grow strong communities around the codebases (Full time, Amsterdam)
-* [Codebase steward for product marketing](product-marketing.md): Make codebases strong competitors to other solutions out there
+* [Codebase steward for product marketing](product-marketing.md): Make codebases strong competitors to other solutions out there (Full time, Amsterdam)
 * [Codebase steward for support](support.md): Provide answers to questions about usage, contributing, procurement and more (Full time, Amsterdam)
 * [Intern](intern.md): Join us as either a junior codebase steward or general intern (Flexible, Amsterdam or remote)
 

--- a/roles/index.md
+++ b/roles/index.md
@@ -10,6 +10,7 @@ We're looking for brilliant people to join our mission. We're currently hiring f
 
 * [Codebase steward for quality](quality.md): Help developers build high quality public code (Full time, Amsterdam)
 * [Codebase steward for community](community.md): Grow strong communities around the codebases (Full time, Amsterdam)
+* [Codebase steward for product marketing](product-marketing.md): Make codebases strong competitors to other solutions out there
 * [Codebase steward for support](support.md): Provide answers to questions about usage, contributing, procurement and more (Full time, Amsterdam)
 * [Intern](intern.md): Join us as either a junior codebase steward or general intern (Flexible, Amsterdam or remote)
 
@@ -19,4 +20,3 @@ We're currently not looking for these roles, however if you think you fit in to 
 
 * Chief Executive Officer
 * Chief Operating Officer
-* [Codebase steward for product marketing](product-marketing.md): Make codebases strong competitors to other solutions out there

--- a/roles/product-marketing.md
+++ b/roles/product-marketing.md
@@ -8,7 +8,7 @@ Come help producers of open source software for public use – such as in cities
 
 We test against the Standard for Public Code to make codebases understandable, reusable and community based. Our standards are high, as well as opinionated, to ensure codebases can be trusted as the infrastructure of society and improve continually, and policy makers can keep technology and architectural choices open.
 
-Part of this effort is to get a wider uptake for these codebases - reused codebases become more cost effective, higher quality, more resilient, and more attractive to contributors. This means policy makers, management and developers in public organizations need to get to know the [codebases](../glossary/codebase-definition.md) and how to use them to solve their problems.
+Part of this effort is to get a wider uptake for these codebases - reused codebases become more cost effective, higher quality, more resilient and more attractive to contributors. This means policy makers, management and developers in public organizations need to get to know the [codebases](../glossary/codebase-definition.md) and how to use them to solve their problems.
 
 ## What the codebase steward for product marketing does
 
@@ -21,6 +21,8 @@ As a codebase steward for product marketing, you work together with the communit
 * help others sell the codebase to their management, coworkers or clients
 * create a buzz around the codebase
 * partake in the community
+
+So if you delight in connecting a product to its natural users and helping them understand that joining an existing open source community is like discovering friends you never knew you had, this may be the role for you.
 
 ### What we expect from all of our team members
 

--- a/roles/product-marketing.md
+++ b/roles/product-marketing.md
@@ -10,7 +10,7 @@ We test against the Standard for Public Code to make codebases understandable, r
 
 Part of this effort is to get a wider uptake for these codebases - reused codebases become more cost effective, higher quality, more resilient, and more attractive to contributors. This means policy makers, management and developers in public organizations need to get to know the [codebases](../glossary/codebase-definition.md) and how to use them to solve their problems.
 
-## What the Codebase steward for product marketing does
+## What the codebase steward for product marketing does
 
 As a codebase steward for product marketing, you work together with the community to make your codebase compelling to others. This means you help:
 
@@ -39,11 +39,11 @@ You should:
 
 We expect our new codebase steward for product marketing to:
 
-- have strong experience in marketing, communications or product management
-- work with a codebase's existing community to build a network of open source enthusiasts in government, government procurement experts, vendors, the wider open source and govtech communities and other stakeholders
-- have previous experience with the open source community or government procurement
-- be excited to help us develop the product marketing process for public code
-- be diplomatic, strategically aware and able to be a strong advocate for the organization
+* have strong experience in marketing, communications or product management
+* work with a codebase's existing community to build a network of open source enthusiasts in government, government procurement experts, vendors, the wider open source and govtech communities and other stakeholders
+* have previous experience with the open source community or government procurement
+* be excited to help us develop the product marketing process for public code
+* be diplomatic, strategically aware and able to be a strong advocate for the organization
 
 ## More information about this position
 

--- a/roles/product-marketing.md
+++ b/roles/product-marketing.md
@@ -22,7 +22,7 @@ As a codebase steward for product marketing, you work together with the communit
 * create a buzz around the codebase
 * partake in the community
 
-So if you delight in connecting a product to its natural users and helping them understand that joining an existing open source community is like discovering friends you never knew you had, this may be the role for you.
+So if you delight in making codebases shine and connecting public purpose codebases to their ideal users, this may be the role for you.
 
 ### What we expect from all of our team members
 
@@ -42,8 +42,8 @@ You should:
 We expect our new codebase steward for product marketing to:
 
 * have strong experience in marketing, communications or product management
-* work with a codebase's existing community to build a network of open source enthusiasts in government, government procurement experts, vendors, the wider open source and govtech communities and other stakeholders
-* have previous experience with the open source community or government [procurement vs technology adoption]
+* work with a codebase's existing community to build a network of people excited for their codebase, including open source enthusiasts in government, government procurement experts, vendors, the wider open source and govtech communities and other stakeholders
+* have previous experience with the open source community or government technology adoption
 * be excited to help us develop the product marketing process for public code
 * be diplomatic, strategically aware and able to be a strong advocate for the organization
 

--- a/roles/product-marketing.md
+++ b/roles/product-marketing.md
@@ -41,7 +41,7 @@ We expect our new codebase steward for product marketing to:
 
 * have strong experience in marketing, communications or product management
 * work with a codebase's existing community to build a network of open source enthusiasts in government, government procurement experts, vendors, the wider open source and govtech communities and other stakeholders
-* have previous experience with the open source community or government procurement
+* have previous experience with the open source community or government [procurement vs technology adoption]
 * be excited to help us develop the product marketing process for public code
 * be diplomatic, strategically aware and able to be a strong advocate for the organization
 

--- a/roles/product-marketing.md
+++ b/roles/product-marketing.md
@@ -4,17 +4,58 @@ type: Resource
 
 # Codebase steward for product marketing
 
-The Foundation for Public Code helps public organizations – such as governments and cities – collaborate on solving their problems by developing open source solutions which, when reused, become more cost effective, of a higher quality, more resilient, and more attractive to contributors.
+Come help producers of open source software for public use – such as in cities and other public organizations – develop and maintain software and policy together. The Foundation for Public Code provides review of codebases that are in our stewardship to help developers build trusted and reliable software that can be widely reused and foster a strong community around it.
 
-In order to get a wider uptake for these codebases – that often compete with closed source software products – policy makers, management and developers in public organizations need to get to know the [codebases](../glossary/codebase-definition.md) and how to use them to solve their problems.
-As a Codebase Steward for Product Marketing you help:
+We test against the Standard for Public Code to make codebases understandable, reusable and community based. Our standards are high, as well as opinionated, to ensure codebases can be trusted as the infrastructure of society and improve continually, and policy makers can keep technology and architectural choices open.
+
+Part of this effort is to get a wider uptake for these codebases - reused codebases become more cost effective, higher quality, more resilient, and more attractive to contributors. This means policy makers, management and developers in public organizations need to get to know the [codebases](../glossary/codebase-definition.md) and how to use them to solve their problems.
+
+## What the Codebase steward for product marketing does
+
+As a codebase steward for product marketing, you work together with the community to make your codebase compelling to others. This means you help:
 
 * make the codebase into a product
-* provide branding for codebases that they stand out from other – often proprietary – solutions
+* provide branding for codebases so that they stand out from other – often proprietary – solutions
 * build the communications channels necessary for getting the word out
 * work to build a market for the codebase and the solution it provides
 * help others sell the codebase to their management, coworkers or clients
 * create a buzz around the codebase
 * partake in the community
 
-This is a full time role in our main offices in Amsterdam, The Netherlands. Relocation possible. Compensation is competitive as well as in line with the public mission of the organization.
+### What we expect from all of our team members
+
+You should:
+
+* share our core values: openness, quality, trust, community, helpfulness
+* understand the value of and be experienced with open source products and communities
+* want to work for the public good
+* have a collaborative work attitude and take pride in making things together
+* be able to work independently
+* be a strong communicator in English
+* have international experience
+* be an active participant in the codebase community you support
+
+### What we expect from the codebase steward for product marketing
+
+We expect our new codebase steward for product marketing to:
+
+- have strong experience in marketing, communications or product management
+- work with a codebase's existing community to build a network of open source enthusiasts in government, government procurement experts, vendors, the wider open source and govtech communities and other stakeholders
+- have previous experience with the open source community or government procurement
+- be excited to help us develop the product marketing process for public code
+- be diplomatic, strategically aware and able to be a strong advocate for the organization
+
+## More information about this position
+
+This is a full time role (40 hours/week) in our main offices in Amsterdam, the Netherlands. Assistance in relocation is possible.
+
+This is a one year contract, with an option to extend. Compensation is competitive as well as in line with the public mission of the organization.
+
+## More about the application process
+
+We enthusiastically encourage people underrepresented in the worlds of technology and government to apply.
+If you want to know more about the position, please get in touch with Boris van Hoytema at boris@publiccode.net or +31 6 17 96 02 05.
+
+To apply for this position, please email Mirjam van Tiel at mirjam@publiccode.net.
+
+We are looking to fill this position in the very near future and will review applications on a rolling basis.

--- a/roles/support.md
+++ b/roles/support.md
@@ -6,17 +6,13 @@ type: Resource
 
 Come help producers of open source software for public use – such as in cities and other public organizations – develop and maintain software and policy together. The Foundation for Public Code provides review of codebases that are in our stewardship to help developers build trusted and reliable software that can be widely reused and foster a strong community around it.
 
-We test against the Standard for Public Code to make codebases understandable, reusable and community based. Our standards are high, as well as opinionated, to ensure codebases can be trusted as the infrastructure of society and improve continually, and policy makers can keep technology and architectural choices open.
+We test against the [Standard for Public Code](https://standard.publiccode.net/) to make codebases understandable, reusable and community based. Our standards are high, as well as opinionated, to ensure codebases can be trusted as the infrastructure of society and improve continually, and policy makers can keep technology and architectural choices open.
 
-> Part of this effort is to [bespoke text contextualising role in broader foundation work].
-
-For the public organizations that would benefit from using, or contributing to, these [Codebases](../glossary/codebase-definition.md) it might not always be easy to get started, know how to use or procure a solution like this or to trust in the Codebase.
+Part of this effort is to make reuse as easy as possible - for the public organizations that would benefit from using or contributing to these [codebases](../glossary/codebase-definition.md), it's not always easy to get started, know how to use or procure a solution like this, or even to trust the codebase.
 
 ## What the codebase steward for support does
 
->As a codebase steward for support, you work together with the community to [bespoke text].
-
-> As a codebase steward for product marketing, you remove technical obstacles to help newcomers adopt a codebase.
+As a codebase steward for support, you help remove technical obstacles to help potential reusers adopt and use a codebase.
 
 This means you help:
 
@@ -27,6 +23,8 @@ This means you help:
 * provide a contact point for issues surrounding a codebase
 * provide support for the community around a codebase to answer these questions themselves
 * partake in the community
+
+If you enjoy using your expertise and network to solve gnarly technical and contractual problems, being a continuous hero and enabler, this role might be for you.
 
 ### What we expect from all of our team members
 

--- a/roles/support.md
+++ b/roles/support.md
@@ -4,18 +4,61 @@ type: Resource
 
 # Codebase steward for support
 
-The Foundation for Public Code helps public organizations – such as governments and cities – collaborate on solving their problems by developing Open Source solutions which, when reused, become more cost effective, of a higher quality, more resilient and attract more contributors.
+Come help producers of open source software for public use – such as in cities and other public organizations – develop and maintain software and policy together. The Foundation for Public Code provides review of codebases that are in our stewardship to help developers build trusted and reliable software that can be widely reused and foster a strong community around it.
+
+We test against the Standard for Public Code to make codebases understandable, reusable and community based. Our standards are high, as well as opinionated, to ensure codebases can be trusted as the infrastructure of society and improve continually, and policy makers can keep technology and architectural choices open.
+
+> Part of this effort is to [bespoke text contextualising role in broader foundation work].
 
 For the public organizations that would benefit from using, or contributing to, these [Codebases](../glossary/codebase-definition.md) it might not always be easy to get started, know how to use or procure a solution like this or to trust in the Codebase.
 
-As a Codebase Steward for Support you help:
+## What the codebase steward for support does
+
+>As a codebase steward for support, you work together with the community to [bespoke text].
+
+This means you help:
 
 * potential users find out how to use codebases
 * provide assistance in procuring solutions based on codebases
 * resolve issues in sales of solutions based on codebases
 * connect potential users to potential (trusted) vendors of solutions
 * provide a contact point for issues surrounding a codebase
-* provide support for the community around a Codebase to answer these questions themselves
+* provide support for the community around a codebase to answer these questions themselves
 * partake in the community
 
-This is a full time role in our main offices in Amsterdam, The Netherlands. Relocation possible. Compensation is competitive as well as in line with the public mission of the organization.
+### What we expect from all of our team members
+
+You should:
+
+* share our core values: openness, quality, trust, community, helpfulness
+* understand the value of and be experienced with open source products and communities
+* want to work for the public good
+* have a collaborative work attitude and take pride in making things together
+* be able to work independently
+* be a strong communicator in English
+* have international experience
+* be an active participant in the codebase community you support
+
+### What we expect from the  codebase steward for support 
+
+We expect our new  codebase steward for support to:
+
+> + be a strong community builder and leader who brings together developers, designers, policy makers, managers and other stakeholders around the open source codebases the Foundation for Public Code has in its stewardship
+* have experience with supporting open source communities
+* be excited to help us develop our codebase support process
+* be diplomatic, strategically aware and able to be a strong advocate for the organization
+
+## More information about this position
+
+This is a full time role (40 hours/week) in our main offices in Amsterdam, the Netherlands. Assistance in relocation is possible.
+
+This is a one year contract, with an option to extend. Compensation is competitive as well as in line with the public mission of the organization.
+
+## More about the application process
+
+We enthusiastically encourage people underrepresented in the worlds of technology and government to apply.
+If you want to know more about the position, please get in touch with Boris van Hoytema at boris@publiccode.net or +31 6 17 96 02 05.
+
+To apply for this position, please email Mirjam van Tiel at mirjam@publiccode.net.
+
+We are looking to fill this position in the very near future and will review applications on a rolling basis.

--- a/roles/support.md
+++ b/roles/support.md
@@ -24,7 +24,7 @@ This means you help:
 * provide support for the community around a codebase to answer these questions themselves
 * partake in the community
 
-If you enjoy using your expertise and network to solve gnarly technical and contractual problems, being a continuous hero and enabler, this role might be for you.
+If you enjoy applying your expertise and network to solve gnarly technical and procurement problems, connecting problems with solutions, this role might be for you.
 
 ### What we expect from all of our team members
 
@@ -39,13 +39,13 @@ You should:
 * have international experience
 * be an active participant in the codebase community you support
 
-### What we expect from the  codebase steward for support 
+### What we expect from the codebase steward for support
 
 We expect our new  codebase steward for support to:
 
-> + be a strong community builder and leader who brings together developers, designers, policy makers, managers and other stakeholders around the open source codebases the Foundation for Public Code has in its stewardship
-> * have experience with supporting open source communities
-* have experience with sales engineering or technology-focused consulting
+* be a strong community connector who brings together vendors, government procurement experts, developers, designers, managers and other stakeholders around the open source codebases the Foundation for Public Code has in its stewardship
+* have experience with supporting open source or government technology communities
+* have experience with technology-focused consulting or sales engineering
 * be excited to help us develop our codebase support process
 * be diplomatic, strategically aware and able to be a strong advocate for the organization
 

--- a/roles/support.md
+++ b/roles/support.md
@@ -16,6 +16,8 @@ For the public organizations that would benefit from using, or contributing to, 
 
 >As a codebase steward for support, you work together with the community to [bespoke text].
 
+> As a codebase steward for product marketing, you remove technical obstacles to help newcomers adopt a codebase.
+
 This means you help:
 
 * potential users find out how to use codebases
@@ -44,7 +46,8 @@ You should:
 We expect our new  codebase steward for support to:
 
 > + be a strong community builder and leader who brings together developers, designers, policy makers, managers and other stakeholders around the open source codebases the Foundation for Public Code has in its stewardship
-* have experience with supporting open source communities
+> * have experience with supporting open source communities
+* have experience with sales engineering or technology-focused consulting
 * be excited to help us develop our codebase support process
 * be diplomatic, strategically aware and able to be a strong advocate for the organization
 


### PR DESCRIPTION
This is a draft PR pending:
- more information about the attributes of our codebase steward for support
- a better understanding of how much procurement experience is a prereq for the product role

Both JDs are also missing snazzy call to action summaries, eg "so if you like doing these awesome things, then this is defo the job for you!"