### PR TITLE
Updated links to careers page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Our [contributor guide for individuals](contributor-guides/for-individuals.md) e
 
 We’re especially interested in learning what you need to implement the [Standard for Public Code](https://standard.publiccode.net/) in your organization. Please [raise an issue](https://standard.publiccode.net/CONTRIBUTING.html) or email us at <info@publiccode.net>.
 
-We're currently hiring codebase stewards - [see our open roles](roles/index.md).
+We're currently hiring codebase stewards - [see our careers and open positions](https://publiccode.net/careers).
 
 ## Public organizations
 

--- a/contributor-guides/for-individuals.md
+++ b/contributor-guides/for-individuals.md
@@ -54,7 +54,7 @@ If you provide us with meaningful contributions we might ask you to become an ad
 
 ## Work for the Foundation
 
-[We're currently hiring](../roles/index.md) codebase stewards to review codebase quality and build strong open source communities. If the prospect of building an ecosystem of public code thrills you, then we'd love to hear from you.
+[We're currently hiring](https://publiccode.net/careers) codebase stewards to review codebase quality and build strong open source communities. If the prospect of building an ecosystem of public code thrills you, then we'd love to hear from you.
 
 ## Responsible disclosure and contact information
 


### PR DESCRIPTION

These links used to point to the `roles` page which has been replaced by the careers section at https://publiccode.net/careers