### PR TITLE
Added line to be explicit about stewardship including tracking changes in the Standard.

### DIFF
--- a/activities/codebase-stewardship/activities.md
+++ b/activities/codebase-stewardship/activities.md
@@ -12,19 +12,20 @@ Community stewardship includes:
 * Supporting committees such as technical steering committees
 * Organizing events
 * Processing feedback and contributions
-  
+
 Product marketing stewardship includes:
 
 * Codebase branding
 * Codebase storytelling, communications and public relations
 * Marketing
 * Developer advocacy
-  
+
 Quality stewardship includes:
 
 * [Codebase auditing](../codebase-auditing/index.md): code, policy and documentation quality assurance
 * Packaging and distributing official versions
 * Security and compatibility monitoring
+* Monitoring codebase compliance towards any future versions of the [Standard for Public Code](https://standard.publiccode.net/) 
 
 Support stewardship includes:
 


### PR DESCRIPTION
This has probably been intended all the time and implicit, but after a discussion with @ericherman we thought it was a good idea to make it explicit.

-----
[View rendered activities/codebase-stewardship/activities.md](https://github.com/publiccodenet/about/blob/activities-standard-addition/activities/codebase-stewardship/activities.md)