### PR TITLE
Community call agenda link added

### DIFF
--- a/activities/codebase-stewardship/activities.md
+++ b/activities/codebase-stewardship/activities.md
@@ -12,6 +12,7 @@ Community stewardship includes:
 * Supporting committees such as technical steering committees
 * Organizing events
 * Processing feedback and contributions
+* Organizing [community calls](https://hackmd.io/@clausmullie/BJGGtcGRE)
 
 Product marketing stewardship includes:
 
@@ -25,7 +26,7 @@ Quality stewardship includes:
 * [Codebase auditing](../codebase-auditing/index.md): code, policy and documentation quality assurance
 * Packaging and distributing official versions
 * Security and compatibility monitoring
-* Monitoring codebase compliance towards any future versions of the [Standard for Public Code](https://standard.publiccode.net/) 
+* Monitoring codebase compliance towards any future versions of the [Standard for Public Code](https://standard.publiccode.net/)
 
 Support stewardship includes:
 

--- a/organization/contact-details.md
+++ b/organization/contact-details.md
@@ -24,3 +24,5 @@ We publish our news and announcements on:
 + [Twitter](http://www.twitter.com/publiccodenet)
 
 We very occasionally update our Facebook and LinkedIn pages.
+
+We arrange bi-weekly community calls: [agenda](https://hackmd.io/@clausmullie/BJGGtcGRE).


### PR DESCRIPTION
I added a mention of the community calls and link to the agenda from activities and contact.

-----
[View rendered activities/codebase-stewardship/activities.md](https://github.com/publiccodenet/about/blob/community-call-link/activities/codebase-stewardship/activities.md)
[View rendered activities/communication/index.md](https://github.com/publiccodenet/about/blob/community-call-link/activities/communication/index.md)
[View rendered organization/contact-details.md](https://github.com/publiccodenet/about/blob/community-call-link/organization/contact-details.md)