### PR TITLE
create product-assets-for-early-incubation.md

### DIFF
--- a/activities/codebase-stewardship/criteria-for-codebase-stewardship.md
+++ b/activities/codebase-stewardship/criteria-for-codebase-stewardship.md
@@ -6,13 +6,10 @@ type: Resource
 
 During the Assess phase in the [codebase stewardship lifecycle](lifecycle.md), the staff of the Foundation for Public Code evaluate whether a codebase is ready and suitable for incubation by checking it against:
 
-
 * the [Standard for Public Code](https://standard.publiccode.net/)
 * the stewardship assessment criteria on this page
 
 Based on this, staff and a potential codebase's current maintainers (for example the project managers or developers) can estimate how much work will be needed during incubation.
-
-
 
 ## The assessment criteria
 

--- a/activities/codebase-stewardship/index.md
+++ b/activities/codebase-stewardship/index.md
@@ -23,6 +23,7 @@ We can provide codebase stewardship from the beginning of the development or for
 * [the codebase stewardship lifecycle](lifecycle.md)
 * [how codebase stewardship works for existing projects](for-existing-projects.md)
 * [criteria we use to assess whether a codebase is ready and suitable for incubation](criteria-for-codebase-stewardship.md)
+* [product assets needed during early incubation](product-assets-for-early-incubation.md)
 
 ## Further reading
 

--- a/activities/codebase-stewardship/product-assets-for-early-incubation.md
+++ b/activities/codebase-stewardship/product-assets-for-early-incubation.md
@@ -44,7 +44,7 @@ We assume the product asset order will be different for greenfield development.
 | 20 | Simple architectural model | Confirms | Quality |
 | 21 | Community fora (or links if hosted elsewhere) | Responsible | Community |
 | 22 | Reports from user research into how codebase is working/could be improved | Provides assistance| Community |
-| 23 | How to deploy/quickstart deployment guide | Verifies/Provides assistance (put into both categories!) | Support |
+| 23 | Quickstart deployment guide | Confirms | Support |
 | 24 | Quickstart user guide | Provides assistance | Support |
 | 25 | Choose license | Provides assistance | Support |
 | 26 | A publiccode.yml file | Creates proposal | Product |

--- a/activities/codebase-stewardship/product-assets-for-early-incubation.md
+++ b/activities/codebase-stewardship/product-assets-for-early-incubation.md
@@ -1,0 +1,52 @@
+---
+type: resource
+---
+
+# Product assets for early incubation
+
+This is a checklist of the most important product assets needed to put an existing codebase on its path to incubation, roughly organized by when they're needed.
+
+## Assumptions
+
+We assume that the chronological goals during incubation are to:
+
+* make sure the codebase is deliberately designed and documented to be reusable
+* create everything needed to enable and support a contributing community
+* focus on collecting evidence and marketing to attract more replicators and contributors
+* improve an active codebase based on performance metrics, user research or new feature requests
+
+We assume each codebase will have different individual needs.
+We assume the product asset order will be different for greenfield development.
+
+## Product assets
+
+| Time line | Product asset | Foundation's role | [Foundation point of contact](https://about.publiccode.net/organization/staff)|
+|----------|-----------------|-------------------|-------------------|
+| 1 | Decide to open source | Confirms | Quality |
+| 2 | Plain English | Confirms | Product |
+| 3 | Organization page on Github | Responsible | CEO |
+| 4 | Disable merge to master | Responsible | Quality |
+| 5 | One paragraph codebase description | Provides assistance | Product |
+| 6 | Document codebase objectives | Confirms | Product |
+| 7 | Configuration options | Confirms | Quality |
+| 8 | One sentence codebase description for github | Creates proposal | Product |
+| 9 | Issue tracker (or link if hosted elsewhere) | Creates proposal | Community/Quality |
+| 10 | Contributing | Responsible | Community |
+| 11 | Explanation of how codebase decisions get made | Creates proposal | Community |
+| 12 | Codebase name | Creates proposal | Product |
+| 13 | Contextual explainer (including policy explanation, users, and process owners) | Provides assistance | Product |
+| 14 | High level overview of what's in the codebase | Confirms | Product, Quality |
+| 15 | README | Provides assistance | Product: is this findable and usable?Quality: is all the right information included? |
+| 16 | Codebase maturity label | Responsible | Quality (release management) |
+| 17 | Codebase brand or logo | Creates proposal | Product |
+| 18 | List of codebase stakeholders with their role (real people) | Provides assistance | Community |
+| 19 | List of experienced vendors | Responsible | Community/Support |
+| 20 | Simple architectural model | Confirms | Quality |
+| 21 | Community fora (or links if hosted elsewhere) | Responsible | Community |
+| 22 | Reports from user research into how codebase is working/could be improved | Provides assistance| Community |
+| 23 | How to deploy/quickstart deployment guide | Verifies/Provides assistance (put into both categories!) | Support |
+| 24 | Quickstart user guide | Provides assistance | Support |
+| 25 | Choose license | Provides assistance | Support |
+| 26 | A publiccode.yml file | Creates proposal | Product |
+
+

--- a/activities/codebase-stewardship/product-assets-for-early-incubation.md
+++ b/activities/codebase-stewardship/product-assets-for-early-incubation.md
@@ -36,7 +36,7 @@ We assume the product asset order will be different for greenfield development.
 | 12 | Codebase name | Creates proposal | Product |
 | 13 | Contextual explainer (including policy explanation, users, and process owners) | Provides assistance | Product |
 | 14 | High level overview of what's in the codebase | Confirms | Product, Quality |
-| 15 | README | Provides assistance | Product: is this findable and usable?Quality: is all the right information included? |
+| 15 | README | Provides assistance | Product: is this findable and usable? Quality: is all the right information included? |
 | 16 | Codebase maturity label | Responsible | Quality (release management) |
 | 17 | Codebase brand or logo | Creates proposal | Product |
 | 18 | List of codebase stakeholders with their role (real people) | Provides assistance | Community |


### PR DESCRIPTION
This was the output of Wednesday's product design workshop.

This fixes #425.

-----
[View rendered activities/codebase-stewardship/criteria-for-codebase-stewardship.md](https://github.com/publiccodenet/about/blob/Incubation-product-asset-chronology/activities/codebase-stewardship/criteria-for-codebase-stewardship.md)
[View rendered activities/codebase-stewardship/index.md](https://github.com/publiccodenet/about/blob/Incubation-product-asset-chronology/activities/codebase-stewardship/index.md)
[View rendered activities/codebase-stewardship/product-assets-for-early-incubation.md](https://github.com/publiccodenet/about/blob/Incubation-product-asset-chronology/activities/codebase-stewardship/product-assets-for-early-incubation.md)