### PR TITLE
List of assumptions added to codebase product asset list

### DIFF
--- a/activities/codebase-stewardship/product-assets-for-early-incubation.md
+++ b/activities/codebase-stewardship/product-assets-for-early-incubation.md
@@ -50,4 +50,15 @@ We assume the product asset order will be different for greenfield development.
 | 25 | Choose license | Provides assistance | Support |
 | 26 | A publiccode.yml file | Creates proposal | Product |
 
+## Assumptions to test
 
+This list is based on assumptions that we're testing as we assess codebases.
+
+These include that:
+
+* making clear which responsibilities the Foundation has vs other parties is useful
+* which other party is responsible will differ by codebase
+* for some codebases, multiple parties will share responsibility for non-Foundation tasks (for example, a codebase's current maintainers and a replicator working together)
+* the size of each task will depend on codebase size and complexity
+* this list can be used as a checklist or plan of work during incubation
+* it might be useful to reframe these as user needs, user stories or jobs to be done

--- a/activities/codebase-stewardship/product-assets-for-early-incubation.md
+++ b/activities/codebase-stewardship/product-assets-for-early-incubation.md
@@ -57,8 +57,8 @@ This list is based on assumptions that we're testing as we assess codebases.
 These include that:
 
 * making clear which responsibilities the Foundation has vs other parties is useful
-* which other party is responsible will differ by codebase
-* for some codebases, multiple parties will share responsibility for non-Foundation tasks (for example, a codebase's current maintainers and a replicator working together)
-* the size of each task will depend on codebase size and complexity
+* which other party is responsible differs by codebase
+* for some codebases, multiple parties share responsibility for non-Foundation tasks (for example, a codebase's current maintainers and a replicator working together)
+* the size of each task depends on codebase size and complexity
 * this list can be used as a checklist or plan of work during incubation
 * it might be useful to reframe these as user needs, user stories or jobs to be done

--- a/activities/codebase-stewardship/product-assets-for-early-incubation.md
+++ b/activities/codebase-stewardship/product-assets-for-early-incubation.md
@@ -61,4 +61,4 @@ These include that:
 * for some codebases, multiple parties share responsibility for non-Foundation tasks (for example, a codebase's current maintainers and a replicator working together)
 * the size of each task depends on codebase size and complexity
 * this list can be used as a checklist or plan of work during incubation
-* it would be helpful to add user needs, user stories or jobs to be done to the list items (as we discussed some user needs when we created the list)
+* it would be helpful to add user needs, user stories or jobs to be done to the list items (as we discussed user needs when we created the list)

--- a/activities/codebase-stewardship/product-assets-for-early-incubation.md
+++ b/activities/codebase-stewardship/product-assets-for-early-incubation.md
@@ -61,4 +61,4 @@ These include that:
 * for some codebases, multiple parties share responsibility for non-Foundation tasks (for example, a codebase's current maintainers and a replicator working together)
 * the size of each task depends on codebase size and complexity
 * this list can be used as a checklist or plan of work during incubation
-* it might be useful to reframe these as user needs, user stories or jobs to be done
+* it would be helpful to add user needs, user stories or jobs to be done to the list items (as we discussed some user needs when we created the list)


### PR DESCRIPTION
In our meeting on codebase stewardship yesterday, I proposed listing our assumptions about how this list could be used so we can get feedback from people involved in codebases (and potentially even use the assumptions to structure the meeting, based on who the other parties are).
These are the assumptions I remember, but maybe there were more?

-----
[View rendered activities/codebase-stewardship/product-assets-for-early-incubation.md](https://github.com/publiccodenet/about/blob/product-marketing-list-assumptions/activities/codebase-stewardship/product-assets-for-early-incubation.md)