### PR TITLE
Add links to staff contributor guides to index pages

### DIFF
--- a/activities/index.md
+++ b/activities/index.md
@@ -14,6 +14,7 @@ Activities that support the above as well as make staff operations work:
 * [Communication](communication/index.md)
 * [Documentation](documentation/index.md)
 * [Member relations](member-relations/index.md)
+* [Onboarding new staff](../contributor-guides/for-staff.md)
 * [Procurement](procurement/index.md)
 * [Recruitment](recruitment/index.md)
 * [Trainings](trainings/index.md)

--- a/activities/recruitment/index.md
+++ b/activities/recruitment/index.md
@@ -19,3 +19,4 @@ For possible applicants:
 See also:
 
 * [Staff](../../organization/staff.md)
+* [Staff contributor guide](../../contributor-guides/for-staff.md)


### PR DESCRIPTION
Another eagle eyed @MirjamvT spot!

-----
[View rendered activities/index.md](https://github.com/publiccodenet/about/blob/contributing/staff/activities/index.md)
[View rendered activities/recruitment/index.md](https://github.com/publiccodenet/about/blob/contributing/staff/activities/recruitment/index.md)