### PR TITLE
s/CCO/CC0/g

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ All branches are tested with every change for broken links, so if some site we l
 
 [![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
 
-To the extent possible under law, the Foundation for Public Code has waived all copyright and related or neighboring rights to the content in this repository. It is [licensed CCO](https://creativecommons.org/publicdomain/zero/1.0/), which basically means that anyone can do anything with it. This does not apply to trademarks or logos of the Foundation for Public Code.
+To the extent possible under law, the Foundation for Public Code has waived all copyright and related or neighboring rights to the content in this repository. It is [licensed CC0](https://creativecommons.org/publicdomain/zero/1.0/), which basically means that anyone can do anything with it. This does not apply to trademarks or logos of the Foundation for Public Code.
 
 Contributors to this repository agree that their contributions also fall under this license and that they have the power and authority to grant this licence.


### PR DESCRIPTION
fixed O vs 0 typo

-----
[View rendered README.md](https://github.com/publiccodenet/about/blob/cc-oh-null/README.md)