### PR TITLE
Not public to secret

### DIFF
--- a/activities/organizing-events/index.md
+++ b/activities/organizing-events/index.md
@@ -61,7 +61,7 @@ As an organization which cares about helping people to collaborate there will be
 
 ## Further reading
 
-* Example of an [event logistics tracking spreadsheet](https://docs.google.com/spreadsheets/d/1l5-DuHCEq4cSF01vkUpZb806to-sqQ3BDcy2IAPpSMg/edit#gid=0) (not publicly shared)
+* Example of an [event logistics tracking spreadsheet (secret)](https://docs.google.com/spreadsheets/d/1l5-DuHCEq4cSF01vkUpZb806to-sqQ3BDcy2IAPpSMg/edit#gid=0). Since this example contains names and email addresses, it can not be publicly shared.
 
 ## Credits
 


### PR DESCRIPTION
Raised in https://github.com/publiccodenet/about/pull/461#discussion_r343076525 we should use "(secret)" in the link and have an explanation as to why it is secret.

-----
[View rendered activities/codebase-stewardship/activities.md](https://github.com/publiccodenet/about/blob/not-public-to-secret/activities/codebase-stewardship/activities.md)
[View rendered activities/organizing-events/index.md](https://github.com/publiccodenet/about/blob/not-public-to-secret/activities/organizing-events/index.md)