### PR TITLE
typo s>z

### DIFF
--- a/activities/recruitment/open-position-template.md
+++ b/activities/recruitment/open-position-template.md
@@ -12,7 +12,7 @@ Come help producers of open source software for public use – such as in cities
 
 We test against the Standard for Public Code to make codebases understandable, reusable and community based. Our standards are high, as well as opinionated, to ensure codebases can be trusted as the infrastructure of society and improve continually, and policy makers can keep technology and architectural choices open.
 
-Part of this effort is to [bespoke text contextualising role in broader foundation work].
+Part of this effort is to [bespoke text contextualizing role in broader foundation work].
 
 ### What the [Job title] does
 


### PR DESCRIPTION


-----
[View rendered activities/recruitment/open-position-template.md](https://github.com/publiccodenet/about/blob/US-spelling-contextualizing/activities/recruitment/open-position-template.md)