### PR TITLE
correct spelling of name of service provider

### DIFF
--- a/activities/recruitment/index.md
+++ b/activities/recruitment/index.md
@@ -14,7 +14,7 @@ These are the resources and processes used for recruitment:
 For possible applicants:
 
 * [Careers section with open positions on the homepage](https://publiccode.net/careers/)
-* [Our Stackoverflow organization page](https://stackoverflow.com/jobs/companies/foundation-for-public-code)
+* [Our Stack Overflow organization page](https://stackoverflow.com/jobs/companies/foundation-for-public-code)
 
 See also:
 


### PR DESCRIPTION


-----
[View rendered activities/recruitment/index.md](https://github.com/publiccodenet/about/blob/stack-overflow-name-correction/activities/recruitment/index.md)