### PR TITLE
CTA for staff bios and vacancies added to org chart

### DIFF
--- a/organization/staff.md
+++ b/organization/staff.md
@@ -12,6 +12,8 @@ As we are a community leadership organization that mostly helps others, we aim f
 
 The staff consists of a manager, [a coordination team](#coordination-team) and specialists.
 
+[Meet our team](https://publiccode.net/staff/) or [check out our open roles](https://publiccode.net/careers/).
+
 ## Domains
 
 ### Operations


### PR DESCRIPTION
Based on @MirjamvT's feedback from a candidate that they didn't understand which roles had been filled, I've added a call to action to the org chart page with links to:
- staff bios
- current vacancies

This PR can now be merged because [HTTP repo PR #37](https://github.com/publiccodenet/http/pull/37) has been merged.

-----
[View rendered organization/staff.md](https://github.com/publiccodenet/about/blob/open-roles-and-staff/organization/staff.md)