### PR TITLE
Remove draft and translation info from contract, decap articles of association titles

### DIFF
--- a/activities/member-relations/membership-contract.md
+++ b/activities/member-relations/membership-contract.md
@@ -2,11 +2,11 @@
 type: resource
 ---
 
-# Draft membership contract
+# Template membership contract
 
-> This is an unofficial English translation of the Dutch membership contract. Square brackets indicate text that is not yet finalized or will be custom for each member.
+> Square brackets indicate text that is not yet finalized or will be custom for each member.
 
-MEMBERSHIP CONTRACT: FOUNDATION FOR PUBLIC CODE VERENIGING
+Membership contract: Foundation for Public Code Vereniging
 
 Dated:  [date]
 

--- a/organization/articles-of-association.md
+++ b/organization/articles-of-association.md
@@ -2,7 +2,7 @@
 type: Resource
 ---
 
-# ARTICLES OF ASSOCIATION: FOUNDATION FOR PUBLIC CODE VERENIGING
+# Articles of association: Foundation for Public Code Vereniging
 
 > This is an unofficial translation of the [original Dutch version of the Foundation for Public Code's articles of association](articles-of-association.nl.md).
 

--- a/organization/articles-of-association.nl.md
+++ b/organization/articles-of-association.nl.md
@@ -2,7 +2,7 @@
 type: Resource
 ---
 
-# AKTE VAN OPRICHTING FOUNDATION FOR PUBLIC CODE VERENIGING
+# Akte van oprichting Foundation for Public Code Vereniging
 
 > This is the original Dutch version of the Foundation for Public Code's articles of association. [Read the unofficial English translation](articles-of-association.md).
 

--- a/organization/staff.md
+++ b/organization/staff.md
@@ -12,7 +12,7 @@ As we are a community leadership organization that mostly helps others, we aim f
 
 The staff consists of a manager, [a coordination team](#coordination-team) and specialists.
 
-[Meet our team](https://publiccode.net/staff/) or [check out our open roles](https://publiccode.net/careers/).
+[Meet our team](https://publiccode.net/team/) or [check out our open roles](https://publiccode.net/careers/).
 
 ## Domains
 


### PR DESCRIPTION
This fixes #491 and #483.


-----
[View rendered activities/member-relations/membership-contract.md](https://github.com/publiccodenet/about/blob/contract-and-articles-of-association/activities/member-relations/membership-contract.md)
[View rendered organization/articles-of-association.md](https://github.com/publiccodenet/about/blob/contract-and-articles-of-association/organization/articles-of-association.md)
[View rendered organization/articles-of-association.nl.md](https://github.com/publiccodenet/about/blob/contract-and-articles-of-association/organization/articles-of-association.nl.md)