### PR TITLE
Link to retro wiki added, plus punctuation and proofreading

### DIFF
--- a/activities/staff-meetings/retrospective.md
+++ b/activities/staff-meetings/retrospective.md
@@ -4,30 +4,29 @@ type: Resource
 
 # Retrospective
 
-This is a template agenda for our regular retrospective
+This is a template agenda for our regular retrospective. Sometimes we use [a different retrospective format](http://retrospectivewiki.org/index.php?title=Retrospective_Plans) when it's a better fit for the situation.
 
 ## Goal
 
-In this session, we look back at how things went in the team and try to identify what can be done better, and identify next steps
+In this session, we look back at how things went in the team and try to identify what can be done better, and identify next steps.
 
 ## Preparation
 
-What you need to prepare:
+We're going to talk about what went well and what didn't, you can prepare this.
 
-* We're going to talk about what went well and what didn't, you can prepare this
-* We're going to give team members praise where it is due, so think about what people have done that was exceptional
+We're going to give team members praise where it is due, so think about what people have done that was exceptional.
 
 ## Agenda
 
-1. Short opening
+1. Short opening.
 2. Write down (if you have not already) on post-its and keep them with you:
   * Notes on what went well
   * Notes on what went poorly
   * Notes of appreciation
-3. One by one everyone puts their notes on the wall explaining them. Whilst doing this the rest listens, no interruptions except for clarifying questions
+3. One by one everyone puts their notes on the wall explaining them. Whilst doing this the rest listens, no interruptions except for clarifying questions.
 
-4. 5 minute break
+4. 5 minute break.
 
-5. Group common themes together
-6. Prioritise things to discuss together
-7. Decide on actions to take, add these to the team backlog as issues
+5. Group common themes together.
+6. Prioritise things to discuss together.
+7. Decide on actions to take, add these to the team backlog as issues.


### PR DESCRIPTION
This page described our most vanilla retro. I've added a link to the retro wiki to set people's expectations that the retro format isn't set in stone, and for educational purposes.
I've made minor proofreading changes since I was on the page anyway.

-----
[View rendered activities/staff-meetings/retrospective.md](https://github.com/publiccodenet/about/blob/extra-link-plus-proofing-love/activities/staff-meetings/retrospective.md)