### PR TITLE
added links to the blog

### DIFF
--- a/activities/codebase-stewardship/community-calls.md
+++ b/activities/codebase-stewardship/community-calls.md
@@ -6,7 +6,7 @@ type: Resource
 
 To enable different kinds of knowledge sharing, we organize a video call every two weeks. The call goes on for about an hour and usually focuses on one topic. The agenda is shared before the meeting and notes are taken.
 
-The community call notes are published on our blog after the call. Call participants may review the notes before they're published.
+The community call notes are published on our [blog](https://blog.publiccode.net) after the call. Call participants may review the notes before they're published.
 
 ## How to join community calls
 

--- a/activities/communication/run-a-community-call.md
+++ b/activities/communication/run-a-community-call.md
@@ -107,4 +107,4 @@ The notetaker reworks the call notes into a call summary.
 The notetaker shares the call summary with people who were on the call for amendment and approval before:
 
 * linking from any relevant GitHub issues or pull requests
-* publishing anywhere else
+* publishing on [the blog](https://blog.publiccode.net)

--- a/activities/events/attending-events.md
+++ b/activities/events/attending-events.md
@@ -51,4 +51,4 @@ There are additional tasks for communications specialists.
 
 ### After
 
-* Publish a blogpost promptly (based on good photos, running notes, team debrief and tweets).
+* [Publish a blogpost](https://github.com/publiccodenet/blog) promptly (based on good photos, running notes, team debrief and tweets).

--- a/activities/events/organizing-events.md
+++ b/activities/events/organizing-events.md
@@ -55,7 +55,7 @@ As an organization which cares about helping people to collaborate there will be
 ## The week after the event
 
 * Upload photos to some storage solution.
-* Use the photos, along with text or quotes from the event on site, in blog, or on social media.
+* Use the photos, along with text or quotes from the event on site, in [the blog](https://blog.publiccode.net), or on social media.
 * Process all expenses for the event.
 * Do a retro of the event. If new things were learned, update this page. Assign other action points immediately so they are not lost.
 

--- a/activities/recruitment/hiring-process.md
+++ b/activities/recruitment/hiring-process.md
@@ -19,6 +19,7 @@ We also use the current team's network to spread awareness of the job opening (v
 
 * the [2 StackOverflow Jobs](https://stackoverflow.com/jobs/companies/foundation-for-public-code) slots we have
 * our [Twitter account](https://twitter.com/publiccodenet)
+* our [blog](https://blog.publiccode.net)
 
 ## Processing reactions of people expressing interest
 

--- a/index.md
+++ b/index.md
@@ -24,7 +24,7 @@ Read more about:
 
 Our [home page at publiccode.net](https://publiccode.net) features a [high level overview of codebase stewardship](https://publiccode.net/codebase-stewardship/), [our team bios](https://publiccode.net/team/), and [the careers page with open positions](https://publiccode.net/careers/).
 
-Additionally, we have separate sites that show our [projects](https://projects.publiccode.net) and [how to use the brand](https://brand.publiccode.net/).
+Additionally, we have separate sites that show our [projects](https://projects.publiccode.net), [how to use the brand](https://brand.publiccode.net/) and our [blog](https://blog.publiccode.net).
 
 ## We need you
 


### PR DESCRIPTION
Previously we removed some links because the blog was not active. Now that it is, let's add some back again :heavy_plus_sign: :link:  :leftwards_arrow_with_hook: 

-----
[View rendered activities/codebase-stewardship/community-calls.md](https://github.com/publiccodenet/about/blob/blog-links/activities/codebase-stewardship/community-calls.md)
[View rendered activities/communication/run-a-community-call.md](https://github.com/publiccodenet/about/blob/blog-links/activities/communication/run-a-community-call.md)
[View rendered activities/events/attending-events.md](https://github.com/publiccodenet/about/blob/blog-links/activities/events/attending-events.md)
[View rendered activities/events/organizing-events.md](https://github.com/publiccodenet/about/blob/blog-links/activities/events/organizing-events.md)
[View rendered activities/recruitment/hiring-process.md](https://github.com/publiccodenet/about/blob/blog-links/activities/recruitment/hiring-process.md)
[View rendered index.md](https://github.com/publiccodenet/about/blob/blog-links/index.md)