### PR TITLE
Remove holiday office closure note

### DIFF
--- a/organization/yearly-schedule.md
+++ b/organization/yearly-schedule.md
@@ -4,8 +4,6 @@ type: resource
 
 # Yearly schedule 2020
 
-> The Foundation for Public Code offices will be closed for the holidays from 21 December 2019 to 6 January 2020.
-
 This schedule shows recurring events the Foundation for Public Code prepares for every year. It includes public holidays when the office is closed.
 
 ## January


### PR DESCRIPTION
Because it's after 6 Jan 2019.

-----
[View rendered organization/yearly-schedule.md](https://github.com/publiccodenet/about/blob/open-again/organization/yearly-schedule.md)