### PR TITLE
Pin faraday to 0.17

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 gem 'github-pages', group: :jekyll_plugins
 gem 'html-proofer'
 gem 'mdl'
+gem "faraday", "~> 0.17"


### PR DESCRIPTION
Until compatibility issues are solved with the `github-pages` gem and it's dependencies I propose pinning this to the last working version.

Issue on the github-pages gem: https://github.com/github/pages-gem/issues/665