### PR TITLE
Update About with new understanding that assessment is a 2-stage process

### DIFF
--- a/activities/codebase-stewardship/create-assessment-spreadsheet.md
+++ b/activities/codebase-stewardship/create-assessment-spreadsheet.md
@@ -13,7 +13,7 @@ An assessment spreadsheet is meant to be shared with current maintainers in orde
 4. Import the values for the answers from the new spreadsheet into a new column in the [codebase tracker spreadsheet](https://docs.google.com/spreadsheets/d/1wUrlZ73S-4BK3sGz87C28d0ReYELCCP4MZnKpB0UKqM/edit#gid=1451436268) (not publicly available), on the tab DASHBOARD.
     * Use the function IMPORTRANGE to link in the answers.
     * Since IMPORTRANGE cannot be drag-copy-cell number increased in Google Sheets, it can save time to use concatenate in Libre Office.
-    * Note that for the section **Dimensions** it is the second column (D) that should be imported. 
+    * Note that for the section **Dimensions** it is the second column (D) that should be imported.
 
 ## Libre Office example
 

--- a/activities/codebase-stewardship/create-assessment-spreadsheet.md
+++ b/activities/codebase-stewardship/create-assessment-spreadsheet.md
@@ -13,11 +13,12 @@ An assessment spreadsheet is meant to be shared with current maintainers in orde
 4. Import the values for the answers from the new spreadsheet into a new column in the [codebase tracker spreadsheet](https://docs.google.com/spreadsheets/d/1wUrlZ73S-4BK3sGz87C28d0ReYELCCP4MZnKpB0UKqM/edit#gid=1451436268) (not publicly available), on the tab DASHBOARD.
     * Use the function IMPORTRANGE to link in the answers.
     * Since IMPORTRANGE cannot be drag-copy-cell number increased in Google Sheets, it can save time to use concatenate in Libre Office.
+    * Note that for the section **Dimensions** it is the second column (D) that should be imported. 
 
 ## Libre Office example
 
- This Libre Office example can be drag-copy-cell number increased and pasted into the dashboard. Just swap out the URL with the one for the newly created spreadsheet.
+ This Libre Office example can be drag-copy-cell number increased and pasted into the dashboard. Just swap out the URL with the one for the newly created spreadsheet. Remember to change the third column to D from row 27.
 
 | A1 | B1 | C1 |
 | -- | -- | -- |
-| `=CONCATENATE("=";B1;C1;""")")` | `IMPORTRANGE("https://docs.google.com/spreadsheets/d/1R4cngGioU3u8gZDp_MdcHUeS234NOfqZxKGfLGiJGtw/edit","TEMPLATE!` | C3 |
+| `=CONCATENATE("=";B1;C1;""")")` | `IMPORTRANGE("https://docs.google.com/spreadsheets/d/1R4cngGioU3u8gZDp_MdcHUeS234NOfqZxKGfLGiJGtw/edit","Stewardship feasibility!` | C3 |

--- a/activities/codebase-stewardship/criteria-for-codebase-stewardship.md
+++ b/activities/codebase-stewardship/criteria-for-codebase-stewardship.md
@@ -2,7 +2,7 @@
 type: Resource
 ---
 
-# Stewardship assessment for existing codebases
+# Stewardship assessment criteria for existing codebases
 
 During the Assess phase in the [codebase stewardship lifecycle](lifecycle.md), the staff of the Foundation for Public Code evaluate whether a codebase is ready and suitable for incubation by checking it against:
 

--- a/activities/codebase-stewardship/criteria-for-codebase-stewardship.md
+++ b/activities/codebase-stewardship/criteria-for-codebase-stewardship.md
@@ -4,7 +4,7 @@ type: Resource
 
 # Assessing existing codebases
 
-During the Assess phase in the [codebase stewardship lifecycle](lifecycle.md), the Foundation for Public Code staff and a codebase's current maintainers evaluate whether a codebase is ready and suitable for incubation. They do this by checking it against:
+During the assess phase in the [codebase stewardship lifecycle](lifecycle.md), the Foundation for Public Code staff and a codebase's current maintainers evaluate whether a codebase is ready and suitable for incubation. They do this by checking it against:
 
 * the stewardship feasibility criteria on this page
 * the [Standard for Public Code](https://standard.publiccode.net/)

--- a/activities/codebase-stewardship/criteria-for-codebase-stewardship.md
+++ b/activities/codebase-stewardship/criteria-for-codebase-stewardship.md
@@ -4,13 +4,12 @@ type: Resource
 
 # Assessing existing codebases
 
-During the Assess phase in the [codebase stewardship lifecycle](lifecycle.md), the staff of the Foundation for Public Code evaluate whether a codebase is ready and suitable for incubation by checking it against:
+During the Assess phase in the [codebase stewardship lifecycle](lifecycle.md), the Foundation for Public Code staff and a codebase's current maintainers evaluate whether a codebase is ready and suitable for incubation. They do this by checking it against:
 
 * the stewardship feasibility criteria on this page
 * the [Standard for Public Code](https://standard.publiccode.net/)
 
-Based on this, staff and a potential codebase's current maintainers (for example the project managers or developers) can estimate how much work will be needed during incubation.
-
+Based on this, staff and a potential codebase's current maintainers (for example the project managers or developers) can estimate how much work will be needed during incubation to meet the Standard for Public Code. This ensures a codebase's current maintainers and community can meaningfully decide whether committing to full Foundation for Public Code stewardship (and the work required of them in incubation) is right for them.
 
 ## Stewardship feasibility criteria
 
@@ -28,6 +27,8 @@ These criteria enable us to decide whether the codebase is a good fit for the Fo
 ## How the criteria are assessed
 
 This list of questions for current maintainers of potential codebases helps us understand their codebase better. To collaborate with current maintainers we use a shared spreadsheet. Use [this guide for creating a new one](create-assessment-spreadsheet.md).
+
+If Foundation for Public Code staff don't believe stewardship is feasible based on these criteria, then we will not proceed with incubation.
 
 ### Business case
 

--- a/activities/codebase-stewardship/criteria-for-codebase-stewardship.md
+++ b/activities/codebase-stewardship/criteria-for-codebase-stewardship.md
@@ -2,7 +2,7 @@
 type: Resource
 ---
 
-# Stewardship assessment criteria for existing codebases
+# Assessing existing codebases
 
 During the Assess phase in the [codebase stewardship lifecycle](lifecycle.md), the staff of the Foundation for Public Code evaluate whether a codebase is ready and suitable for incubation by checking it against:
 

--- a/activities/codebase-stewardship/criteria-for-codebase-stewardship.md
+++ b/activities/codebase-stewardship/criteria-for-codebase-stewardship.md
@@ -2,16 +2,17 @@
 type: Resource
 ---
 
-# Stewardship assessment criteria for existing codebases
+# Stewardship assessment for existing codebases
 
 During the Assess phase in the [codebase stewardship lifecycle](lifecycle.md), the staff of the Foundation for Public Code evaluate whether a codebase is ready and suitable for incubation by checking it against:
 
+* the stewardship feasibility criteria on this page
 * the [Standard for Public Code](https://standard.publiccode.net/)
-* the stewardship assessment criteria on this page
 
 Based on this, staff and a potential codebase's current maintainers (for example the project managers or developers) can estimate how much work will be needed during incubation.
 
-## The assessment criteria
+
+## Stewardship feasibility criteria
 
 These criteria enable us to decide whether the codebase is a good fit for the Foundation for Public Code:
 

--- a/activities/codebase-stewardship/for-existing-projects.md
+++ b/activities/codebase-stewardship/for-existing-projects.md
@@ -4,10 +4,13 @@ type: Resource
 
 # Codebase stewardship for existing projects
 
-Codebase stewardship can be provided to an existing codebase.
-In that case, there might be some important considerations about how to transition and budget for that.
+Codebase stewardship can be provided to an existing codebase. In this case, there might be some important considerations about how to transition and budget for that.
 
-Before entering the [codebase stewardship lifecycle](lifecycle.md) all potential codebases are evaluated according to our [criteria for codebase stewardship](criteria-for-codebase-stewardship.md). To help tracking codebases in Odoo consistently, use [this template](odoo-codebase-template.md).
+## How to start
+
+As set out in the [codebase stewardship lifecycle](lifecycle.md), a codebase must first be proposed to the Foundation for Public Code.
+
+Existing codebases are then [assessed against the stewardship feasibility criteria](criteria-for-codebase-stewardship.md) and [Standard for Public Code](https://standard.publiccode.net/).
 
 ## What developing organizations need to do
 
@@ -33,3 +36,7 @@ We will:
 * develop storytelling and marketing of the project based on best practices and research
 * provide prospective reusers and contributors with a helpdesk to answer their questions on issues ranging from installations to procurement
 * help create budgets and frame costs
+
+## Further reading
+
+* [Template for adding a new codebase to Odoo](https://github.com/publiccodenet/about/blob/assessment-is-a-2-stage-process/activities/codebase-stewardship/odoo-codebase-template.md)

--- a/activities/codebase-stewardship/lifecycle.md
+++ b/activities/codebase-stewardship/lifecycle.md
@@ -9,7 +9,7 @@ How we deliver codebase stewardship is based around the lifecycle of stewardship
 
 ## Assessment
 
-In order to decide on if and how we can perform incubating stewardship [we assess](open-assessment.md) the codebase and its community together with the community. If it is an [existing codebase](for-existing-projects.md) we look at the [stewardship feasibility](https://about.publiccode.net/activities/codebase-stewardship/criteria-for-codebase-stewardship.html) first. 
+In order to decide on if and how we can perform incubating stewardship [we assess](open-assessment.md) the codebase and its community together with the community. If it is an [existing codebase](for-existing-projects.md) we look at the [stewardship feasibility](https://about.publiccode.net/activities/codebase-stewardship/criteria-for-codebase-stewardship.html) first.
 
 If codebase stewardship is feasible, or if it is a new codebase, we then do a [Standard for Public Code](https://standard.publiccode.net/) gap analysis.
 
@@ -25,7 +25,6 @@ Codebases that are in incubation do not yet have the maturity of code and commun
 During incubation, the community works to make the codebase fully Standard compliant (supported by the Foundation for Public Code).
 
 Repositories of codebases in incubation will have clear indicators that the codebase and community are not yet mature, displayed in prominent places.
-
 
 ## Full stewardship
 

--- a/activities/codebase-stewardship/lifecycle.md
+++ b/activities/codebase-stewardship/lifecycle.md
@@ -9,13 +9,23 @@ How we deliver codebase stewardship is based around the lifecycle of stewardship
 
 ## Assessment
 
-In order to decide on if and how we can perform incubating stewardship [we assess](open-assessment.md) the codebase and its community together with the community. If it is an [existing codebase](for-existing-projects.md) we look at the stewardship feasibility first. Then, or if it is a new codebase, we do a standard gap analysis.
+In order to decide on if and how we can perform incubating stewardship [we assess](open-assessment.md) the codebase and its community together with the community. If it is an [existing codebase](for-existing-projects.md) we look at the [stewardship feasibility](https://about.publiccode.net/activities/codebase-stewardship/criteria-for-codebase-stewardship.html) first. 
+
+If codebase stewardship is feasible, or if it is a new codebase, we then do a [Standard for Public Code](https://standard.publiccode.net/) gap analysis.
+
+At the end of assessment, the community:
+
+* knows what work will be required to make the codebase compliant with the Standard
+* can meaningfully decide whether to commit to becoming fully stewarded by the Foundation for Public Code
 
 ## Incubating stewardship
 
 Codebases that are in incubation do not yet have the maturity of code and community that we require in the [Standard for Public Code](https://standard.publiccode.net/) and that might be required in the codebase governance.
 
+During incubation, the community works to make the codebase fully Standard compliant (supported by the Foundation for Public Code).
+
 Repositories of codebases in incubation will have clear indicators that the codebase and community are not yet mature, displayed in prominent places.
+
 
 ## Full stewardship
 

--- a/activities/codebase-stewardship/lifecycle.md
+++ b/activities/codebase-stewardship/lifecycle.md
@@ -9,9 +9,7 @@ How we deliver codebase stewardship is based around the lifecycle of stewardship
 
 ## Assessment
 
-In order to decide on if and how we can perform incubating stewardship [we assess](open-assessment.md) the codebase and its community together with the community.
-
-For existing codebases we start with the [assessment criteria for existing codebases](for-existing-projects.md).
+In order to decide on if and how we can perform incubating stewardship [we assess](open-assessment.md) the codebase and its community together with the community. If it is an [existing codebase](for-existing-projects.md) we look at the stewardship feasibility first. Then, or if it is a new codebase, we do a standard gap analysis.
 
 ## Incubating stewardship
 

--- a/activities/codebase-stewardship/open-assessment.md
+++ b/activities/codebase-stewardship/open-assessment.md
@@ -5,7 +5,7 @@ explains: how we do assessments in the open
 
 # How we do assessments in the open
 
-This guide is intended to help codebase stewards start assessment on a codebase that has entered the Assess phase (see [the lifecycle](lifecycle.md)).
+This guide is intended to help codebase stewards start assessment on a codebase that has entered the assess phase (see [the lifecycle](lifecycle.md)).
 
 ## Principles
 

--- a/activities/codebase-stewardship/open-assessment.md
+++ b/activities/codebase-stewardship/open-assessment.md
@@ -5,15 +5,15 @@ explains: how we do assessments in the open
 
 # How we do assessments in the open
 
-This guide is intended to help codebase stewards to start assessment on a codebase that has entered the Assess phase (see [the lifecycle](lifecycle.md)).
+This guide is intended to help codebase stewards start assessment on a codebase that has entered the Assess phase (see [the lifecycle](lifecycle.md)).
 
 ## Principles
 
-Assessment should as much as possible take place in the open and be done together with the community of the codebase.
+As much as possible, assessment should take place in the open and be done together with the community of the codebase.
 
 ## Steps
 
-1. Get explicit approval to start an open assessment by asking the maintainer. Consider communicating about that assessment is starting, preferrably by encouraging the maintainer to do it, and possibly on [the blog](https://blog.publiccode.net) as well.
+1. Get explicit approval to start an open assessment by asking the maintainer. Consider communicating that assessment is starting, preferrably by encouraging the maintainer to do it, and possibly on [the blog](https://blog.publiccode.net) as well.
 2. [Create an assessment spreadsheet and link with the dashboard](create-assessment-spreadsheet.md).
 3. Create an issue in the repository for the codebase that links to the spreadsheet ([template](assessment-issue-template.md)).
 4. Start assessing.

--- a/activities/codebase-stewardship/open-assessment.md
+++ b/activities/codebase-stewardship/open-assessment.md
@@ -13,7 +13,7 @@ Assessment should as much as possible take place in the open and be done togethe
 
 ## Steps
 
-1. Get explicit approval to start an open assessment by asking the maintainer.
+1. Get explicit approval to start an open assessment by asking the maintainer. Consider communicating about that assessment is starting, preferrably by encouraging the maintainer to do it, and possibly on [the blog](https://blog.publiccode.net) as well.
 2. [Create an assessment spreadsheet and link with the dashboard](create-assessment-spreadsheet.md).
 3. Create an issue in the repository for the codebase that links to the spreadsheet ([template](assessment-issue-template.md)).
 4. Start assessing.


### PR DESCRIPTION
- rename 'stewardship assessment' to 'stewardship feasibility'

-----
[View rendered activities/codebase-stewardship/criteria-for-codebase-stewardship.md](https://github.com/publiccodenet/about/blob/assessment-is-a-2-stage-process/activities/codebase-stewardship/criteria-for-codebase-stewardship.md)