### PR TITLE
Splitting community calls

### DIFF
--- a/activities/codebase-stewardship/activities.md
+++ b/activities/codebase-stewardship/activities.md
@@ -29,7 +29,7 @@ Community stewardship includes:
 * supporting committees such as technical steering committees
 * [organizing events](../events/index.md)
 * processing feedback and contributions
-* organizing [community calls](/community-calls/)
+* organizing [community calls](/community-calls/index.md)
 * organizing [workshops](../workshops/index.md)
 
 ## Quality

--- a/activities/codebase-stewardship/activities.md
+++ b/activities/codebase-stewardship/activities.md
@@ -29,7 +29,7 @@ Community stewardship includes:
 * supporting committees such as technical steering committees
 * [organizing events](../events/index.md)
 * processing feedback and contributions
-* organizing [community calls](community-calls.md)
+* organizing [community calls](/community-calls/)
 * organizing [workshops](../workshops/index.md)
 
 ## Quality

--- a/activities/codebase-stewardship/community-calls/index.md
+++ b/activities/codebase-stewardship/community-calls/index.md
@@ -1,5 +1,5 @@
 ---
-type: Resource
+type: Index
 ---
 
 # Community calls
@@ -10,10 +10,16 @@ We also organize a video call for our own codebases the first Thursday of the mo
 
 The community call notes are published on our [blog](https://blog.publiccode.net) after the call. Call participants may review the notes before they're published.
 
+## Guides to run a Standard for Public Code community call
+
+* [Preparing a community call](preparing-community-call.md)
+* [Running a community call](running-community-call.md)
+* [Post-processing a community call](post-process-community-call.md)
+
 ## How to join our community calls
 
 [Sign up for community call invitations](https://forms.gle/gn7wR2Eaxbv5g1BF9).
 
 ## Further reading
 
-* [Running a community call](../communication/run-a-community-call.md)
+* [Running a Foundation for Public code community call](../../communication/run-a-community-call.md)

--- a/activities/codebase-stewardship/community-calls/post-process-community-call.md
+++ b/activities/codebase-stewardship/community-calls/post-process-community-call.md
@@ -7,6 +7,6 @@ explains: How to post-process a community call
 
 The notetaker reworks the call notes into a call summary.
 
-The notetaker shares the call summary with people who were on the call for amendment and approval before [publishing on the blog](../../communication/community-call-blogposts.md).
+The notetaker shares the call summary with people who were on the call for amendment and approval before publishing on the blog.
 
 Depending on what the community call was about and what the conclusions were, update related issues and pull requests [in GitHub](https://github.com/publiccodenet/standard) and link to the blog post as an explanation for the update.

--- a/activities/codebase-stewardship/community-calls/post-process-community-call.md
+++ b/activities/codebase-stewardship/community-calls/post-process-community-call.md
@@ -1,0 +1,12 @@
+---
+type: Guide
+explains: How to post-process a community call
+---
+
+# Post-processing a community call
+
+The notetaker reworks the call notes into a call summary.
+
+The notetaker shares the call summary with people who were on the call for amendment and approval before [publishing on the blog](../../communication/community-call-blogposts.md).
+
+Depending on what the community call was about and what the conclusions were, update related issues and pull requests [in GitHub](https://github.com/publiccodenet/standard) and link to the blog post as an explanation for the update.

--- a/activities/codebase-stewardship/community-calls/preparing-community-call.md
+++ b/activities/codebase-stewardship/community-calls/preparing-community-call.md
@@ -40,7 +40,7 @@ Invite codebase stewards and other Foundation for Public Code staff that could b
 The chair and the notetaker:
 
 * create a notes document on HackMD.io for this call
-* add "updates since the last community call" to the notes - keep this to three items or fewer (we want the community call to be a dialogue, not a broadcast). If possible, focus on Standard related updates
+* add "updates since the last community call" to the notes - keep this to three items or fewer (we want the community call to be a dialogue, not a broadcast). If possible, focus on Standard related updates, but other news relevant to the community are also fine. All updates should be linkable, meaning that they should already be published somewhere else
 * put these in the call notes document
 
 Ask the [communications coordinator](../../../organization/staff.md#communications) if you need help with updates.

--- a/activities/codebase-stewardship/community-calls/preparing-community-call.md
+++ b/activities/codebase-stewardship/community-calls/preparing-community-call.md
@@ -24,7 +24,7 @@ Together with the codebase stewards figure out if there is anything specific you
 
 Start with updating Odoo with people that signed up on the form since the last community call. Add the tags to the contacts to make it possible to have Odoo select them for the appropriate call.
 
-* Send out invitations ([template](../../community-call-invite-template.md))
+* Send out invitations ([template](../../communication/community-call-invite-template.md))
 * Update the calendar by adding newly signed up people and the current agenda
 
 ### Internal
@@ -43,6 +43,6 @@ The chair and the notetaker:
 * add "updates since the last community call" to the notes - keep this to three items or fewer (we want the community call to be a dialogue, not a broadcast). If possible, focus on Standard related updates
 * put these in the call notes document
 
-Ask the [communications coordinator](../../organization/staff.md#communications) if you need help with updates.
+Ask the [communications coordinator](../../../organization/staff.md#communications) if you need help with updates.
 
 The notetaker will take notes during the call in the same document.

--- a/activities/codebase-stewardship/community-calls/preparing-community-call.md
+++ b/activities/codebase-stewardship/community-calls/preparing-community-call.md
@@ -1,0 +1,48 @@
+---
+type: Guide
+explains: How to prepare a community call
+---
+
+# Preparing a Standard for Public Code community call
+
+## Set agenda
+
+Together with the codebase stewards figure out if there is anything specific you want to discuss on the next call. As a help, take a look at the [open issues](https://github.com/publiccodenet/standard/issues) and [open pull requests](https://github.com/publiccodenet/standard/pulls) in GitHub.
+
+* Update the [agenda](https://hackmd.io/-OegeqvoThCbAsw3c3gIjw?edit)
+
+### Templated agenda items
+
+1. Opening the call
+  * Introduction round (all)
+  * Short update from the Foundation for Public Code (chair)
+2. Substance of the call
+
+## Invitations
+
+### External
+
+Start with updating Odoo with people that signed up on the form since the last community call. Add the tags to the contacts to make it possible to have Odoo select them for the appropriate call.
+
+* Send out invitations ([template](../../community-call-invite-template.md))
+* Update the calendar by adding newly signed up people and the current agenda
+
+### Internal
+
+Invite codebase stewards and other Foundation for Public Code staff that could be benefit from and to the call. Be clear in assigning roles/tasks to them so they know what is expected and have a chance to prepare for the call. Commonly used roles are:
+
+* the chair, who opens the call on behalf of the Foundation
+* experts leading specific substantive sections of the call (otherwise this is the chair)
+* the notetaker
+
+## Meeting preparations
+
+The chair and the notetaker:
+
+* create a notes document on HackMD.io for this call
+* add "updates since the last community call" to the notes - keep this to three items or fewer (we want the community call to be a dialogue, not a broadcast). If possible, focus on Standard related updates
+* put these in the call notes document
+
+Ask the [communications coordinator](../../organization/staff.md#communications) if you need help with updates.
+
+The notetaker will take notes during the call in the same document.

--- a/activities/codebase-stewardship/community-calls/running-community-call.md
+++ b/activities/codebase-stewardship/community-calls/running-community-call.md
@@ -11,7 +11,7 @@ Call-in link: <https://meet.google.com/tfd-acmn-tkb>
 
 Agenda link: <https://hackmd.io/-OegeqvoThCbAsw3c3gIjw>
 
-Have each person join the call on a separate connection aligned with our [conference call etiquette](../communication/conference-call-etiquette.md).
+Have each person join the call on a separate connection aligned with our [conference call etiquette](../../communication/conference-call-etiquette.md).
 
 ### No show
 

--- a/activities/codebase-stewardship/community-calls/running-community-call.md
+++ b/activities/codebase-stewardship/community-calls/running-community-call.md
@@ -1,44 +1,17 @@
 ---
 type: Guide
-explains: what to set up and how to run and follow up on a community call
+explains: How to run a community call
 ---
 
 # Running a community call
-
-The roles on the community call are:
-
-* the chair, who opens the call on behalf of the Foundation
-* experts leading specific substantive sections of the call (otherwise this is the chair)
-* the notetaker
-
-## Before the call
-
-The chair and the notetaker:
-
-* create a notes HackMD.io document for this call
-* add "updates since the last community call" to the notes - keep this to three items or fewer (we want the community call to be a dialogue, not a broadcast). If possible, focus on community related updates
-* put these in the call notes doc
-* update the [agenda](https://hackmd.io/-OegeqvoThCbAsw3c3gIjw?edit)
-* send out invitations ([template](community-call-invite-template.md))
-
-Ask the [communications coordinator](../../organization/staff.md#communications) if you need help with Foundation updates.
-
-The notetaker will take notes during the call in the same document.
-
-Have each person join the call on a separate connection aligned with our [conference call etiquette](conference-call-etiquette.md).
-
-## Templated agenda items
-
-1. Opening the call
-  * Introduction round (all)
-  * Short update from the Foundation for Public Code (chair)
-2. Substance of the call
 
 ## 1. Opening the call
 
 Call-in link: <https://meet.google.com/tfd-acmn-tkb>
 
 Agenda link: <https://hackmd.io/-OegeqvoThCbAsw3c3gIjw>
+
+Have each person join the call on a separate connection aligned with our [conference call etiquette](conference-call-etiquette.md).
 
 ### No show
 
@@ -48,7 +21,7 @@ If nobody joins at the call starting time, wait at least 15 minutes before closi
 
 The chair:
 
-* welcomes everyone to the community call on behalf of the Foundation for Public Code
+* welcomes everyone to the Standard for Public Code community call on behalf of the Foundation for Public Code
 * briefly mentions what is on the agenda for today (without being so specific that discussions start)
 * notes that the call will be minuted, but not recorded, and the minutes published on our blog. Everyone on the call will get the chance to review and fix the minutes before they're published
 * asks everyone to introduce themselves - who are you, do you represent an organization, what's your interest in public code or the topic for this call?
@@ -56,16 +29,18 @@ The chair:
 * asks someone else to go next (for example, someone they know to be excited about the topic, or a friend of the Foundation, or an extrovert)
 * keeps track of who's introduced themselves and nudges anyone who hasn't by the end
 
+The notetaker keeps track on who participated on the call.
+
 ### Short update from the Foundation for Public Code
 
 The chair:
 
 * thanks everyone for introducing themselves
 * asks if everyone's familiar with the Foundation
-* gives optional Foundation intro
+* gives optional introduction to the Foundation for Public Code
 * gives update since the last community call (from the notes document)
 
-#### Optional intro to the Foundation
+#### Optional introduction to the Foundation for Public Code
 
 The Foundation for Public Code is a member-driven, member-funded and member-governed association of public organizations.
 
@@ -85,6 +60,8 @@ The chair then either:
 * hands over to the (first) substantive expert
 * facilitates discussion of the substantive agenda themselves
 
+The notetaker takes notes in as much details as possible. More is better than less, and will be cleaned up during the [post-process](post-process-community-call.md).
+
 ## 3. Closing the call
 
 When either the time is up, or all topics have been exhausted, the chair:
@@ -93,12 +70,3 @@ When either the time is up, or all topics have been exhausted, the chair:
 * reminds everyone that there is another call in a month and asks for suggested topics for that call
 * explains that the minutes will be sent out for review
 * thanks everyone for participating in the call
-
-## After the call
-
-The notetaker reworks the call notes into a call summary.
-
-The notetaker shares the call summary with people who were on the call for amendment and approval before:
-
-* linking from any relevant GitHub issues or pull requests
-* publishing on [the blog](https://blog.publiccode.net)

--- a/activities/codebase-stewardship/community-calls/running-community-call.md
+++ b/activities/codebase-stewardship/community-calls/running-community-call.md
@@ -11,7 +11,7 @@ Call-in link: <https://meet.google.com/tfd-acmn-tkb>
 
 Agenda link: <https://hackmd.io/-OegeqvoThCbAsw3c3gIjw>
 
-Have each person join the call on a separate connection aligned with our [conference call etiquette](conference-call-etiquette.md).
+Have each person join the call on a separate connection aligned with our [conference call etiquette](../communication/conference-call-etiquette.md).
 
 ### No show
 

--- a/activities/codebase-stewardship/for-existing-projects.md
+++ b/activities/codebase-stewardship/for-existing-projects.md
@@ -39,4 +39,4 @@ We will:
 
 ## Further reading
 
-* [Template for adding a new codebase to Odoo](https://github.com/publiccodenet/about/blob/assessment-is-a-2-stage-process/activities/codebase-stewardship/odoo-codebase-template.md)
+* [Template for adding a new codebase to Odoo](odoo-codebase-template.md)

--- a/activities/communication/conference-call-etiquette.md
+++ b/activities/communication/conference-call-etiquette.md
@@ -1,0 +1,11 @@
+---
+type: resource
+---
+
+# Conference call etiquette
+
+Each person should use their own computer so everyone on the call is symbolically equal.
+
+The chair should be on the call 5 minutes before the call starting time.
+
+Consider putting a Foundation for Public Code poster on the wall behind you.


### PR DESCRIPTION
Both in terms of Standard for Public Code vs Foundation for Public Code community and dividing it up into three parts for easier overview. Solves #504 

-----
[View rendered activities/codebase-stewardship/community-calls/index.md](https://github.com/publiccodenet/about/blob/standard-community-call/activities/codebase-stewardship/community-calls/index.md)
[View rendered activities/codebase-stewardship/community-calls/post-process-community-call.md](https://github.com/publiccodenet/about/blob/standard-community-call/activities/codebase-stewardship/community-calls/post-process-community-call.md)
[View rendered activities/codebase-stewardship/community-calls/preparing-community-call.md](https://github.com/publiccodenet/about/blob/standard-community-call/activities/codebase-stewardship/community-calls/preparing-community-call.md)
[View rendered activities/codebase-stewardship/community-calls/running-community-call.md](https://github.com/publiccodenet/about/blob/standard-community-call/activities/codebase-stewardship/community-calls/running-community-call.md)
[View rendered activities/communication/conference-call-etiquette.md](https://github.com/publiccodenet/about/blob/standard-community-call/activities/communication/conference-call-etiquette.md)
[View rendered activities/communication/run-a-community-call.md](https://github.com/publiccodenet/about/blob/standard-community-call/activities/communication/run-a-community-call.md)