### PR TITLE
Remove good friday from yearly schedule

### DIFF
--- a/organization/yearly-schedule.md
+++ b/organization/yearly-schedule.md
@@ -22,7 +22,7 @@ This schedule shows recurring events the Foundation for Public Code prepares for
 
 2 April: Foundation for Public Code General Assembly
 
-10-13 April: Good Friday and Easter Monday (public holidays in the Netherlands, office closed)
+10-13 April: Easter Monday (public holiday in the Netherlands, office closed)
 
 27 April: King's day (public holiday in the Netherlands, office closed)
 

--- a/organization/yearly-schedule.md
+++ b/organization/yearly-schedule.md
@@ -22,7 +22,7 @@ This schedule shows recurring events the Foundation for Public Code prepares for
 
 2 April: Foundation for Public Code General Assembly
 
-10-13 April: Easter Monday (public holiday in the Netherlands, office closed)
+13 April: Easter Monday (public holiday in the Netherlands, office closed)
 
 27 April: King's day (public holiday in the Netherlands, office closed)
 


### PR DESCRIPTION
After reading the contract it became apparent that although good Friday is a national holiday, it is not one the office is closed on.

-----
[View rendered organization/yearly-schedule.md](https://github.com/publiccodenet/about/blob/remove-good-friday/organization/yearly-schedule.md)