### PR TITLE
Clarify staff-meeting index.

### DIFF
--- a/activities/staff-meetings/index.md
+++ b/activities/staff-meetings/index.md
@@ -1,9 +1,10 @@
 ---
 type: Index
-explains: This index contains the resources and guides for staff to run and participate in staff meetings.
 ---
 
-# Staff meetings at the Foundation for Public Code
+# Staff meeting templates
+
+All meetings have an agenda in the meeting calendar invitation. For common meetings that have to be planned often you can use the folling templates:
 
 * [Event debrief](event-debrief.md)
 * [Retrospective](retrospective.md)


### PR DESCRIPTION
Alleviates #590. Which can be closed in my opinion after merging this.

-----
[View rendered activities/staff-meetings/index.md](https://github.com/publiccodenet/about/blob/meeting-templates-index/activities/staff-meetings/index.md)