### PR TITLE
Point to the team calendar for standup

### DIFF
--- a/contributor-guides/for-staff.md
+++ b/contributor-guides/for-staff.md
@@ -16,7 +16,7 @@ Here are some important things to figure out in the first couple of days:
 * Manual of me - fill out your own and read the existing ones
 * Github - push a branch, make a pull request (maybe to improve this page!)
 * Splitwise - if you want to join the shared lunch groceries
-* Attend morning standup ritual at 10:00
+* Attend morning standup ritual that is in the team calendar
 * Attend sprint retrospective & planning - review the kanbans beforehand
 * Tentoo NMBRS ESS (employee self service) mobile app - to [request leave](../activities/staff-management/leave.md), [file expenses](../activities/staff-management/expense.md) and see your payslips
 


### PR DESCRIPTION
Alleviates #590. This change also removes the time from this file, which reduces content debt by making it possible to change the time in the calendar without having to update this page first.

-----
[View rendered contributor-guides/for-staff.md](https://github.com/publiccodenet/about/blob/point-to-calendar/contributor-guides/for-staff.md)