### PR TITLE
Remove 'hosted and managed' in codebase definition

### DIFF
--- a/glossary/codebase-definition.md
+++ b/glossary/codebase-definition.md
@@ -8,4 +8,4 @@ Any discrete package of code (both source and policy), the tests and documentati
 
 This can be in the form of – for example – a document or a version-control repository.
 
-Codebases of the [products stewarded by the Foundation for Public Code](../activities/codebase-stewardship/index.md) are hosted and managed by the Foundation for Public Code.
+Codebases of the [products stewarded by the Foundation for Public Code](../activities/codebase-stewardship/index.md) are supported by the Foundation for Public Code in organization, governance, infrastructure and whatever it needs to scale.

--- a/glossary/codebase-definition.md
+++ b/glossary/codebase-definition.md
@@ -8,4 +8,4 @@ Any discrete package of code (both source and policy), the tests and documentati
 
 This can be in the form of – for example – a document or a version-control repository.
 
-Codebases of the [products stewarded by the Foundation for Public Code](../activities/codebase-stewardship/index.md) are supported by the Foundation for Public Code in organization, governance, infrastructure and whatever it needs to scale.
+Codebases of the [products stewarded by the Foundation for Public Code](../activities/codebase-stewardship/index.md) are supported by the Foundation for Public Code in organization, governance, infrastructure and whatever they need to scale.


### PR DESCRIPTION
Hosted and managed gave the idea that we have ownership, whilst we would like to have this with the community as much as possible.

Fixes #139.

-----
[View rendered glossary/codebase-definition.md](https://github.com/publiccodenet/about/blob/hosted-nor-managed/glossary/codebase-definition.md)