### PR TITLE
Add roadmap template

### DIFF
--- a/activities/supporting-codebase-governance/index.md
+++ b/activities/supporting-codebase-governance/index.md
@@ -75,7 +75,7 @@ Some common [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern) that we 
 These are some tools we've developed to make codebase governance easier:
 
 * The [governance game](game/index.md) and the [governance exercise](exercise/index.md) are useful tools to employ early in the process. It helps people reflect on what governances means for a codebase, the complexity around it, and suggests things worth considering during set up. It is also useful as a tool for visualizing how a current governance model is set up or could be changed.
-* [Technical roadmap template](technical-roadmap-template.md)
+* [Technical roadmap template](technical-roadmap-template.md).
 
 ## Further reading
 

--- a/activities/supporting-codebase-governance/index.md
+++ b/activities/supporting-codebase-governance/index.md
@@ -70,9 +70,12 @@ Some common [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern) that we 
   * If a majority (or all) of the reviewers are part of a single organization that doesn't dedicate time to reviewing code contributions from other organizations, the backlog of pull requests to review will grow. If the model is too rigid, timely merging might become a problem.
 * A model requiring perfect consensus or even unanimous votes might get caught in decision paralysis if the voting members usually have different opinions.
 
-## Workshop
+## Tools to support governance
 
-The [governance game](game/index.md) and the [governance exercise](exercise/index.md) are useful tools to employ early in the process. It helps people reflect on what governances means for a codebase, the complexity around it, and suggests things worth considering during set up. It is also useful as a tool for visualizing how a current governance model is set up or could be changed.
+These are some tools we've developed to make codebase governance easier:
+
+* The [governance game](game/index.md) and the [governance exercise](exercise/index.md) are useful tools to employ early in the process. It helps people reflect on what governances means for a codebase, the complexity around it, and suggests things worth considering during set up. It is also useful as a tool for visualizing how a current governance model is set up or could be changed.
+* [Technical roadmap template](technical-roadmap-template.md)
 
 ## Further reading
 

--- a/activities/supporting-codebase-governance/technical-roadmap-template.md
+++ b/activities/supporting-codebase-governance/technical-roadmap-template.md
@@ -20,22 +20,15 @@ They will change when relevant information is absorbed by the team.
 ## What is currently being worked on
 
 *Not all sections need to be filled in, but the title and why are recommended.*
+You can add new items by adding a heading for the title, why, how, and what.
 
-### Technical thing 1
+### [Technical thing name or title]
 
-#### Why 1
+#### Why
 
-#### How 1
+#### How
 
-#### What 1
-
-### Technical thing 2
-
-#### Why 2
-
-#### How 2
-
-#### What 2
+#### What
 
 ## Themes that will likely be worked on next
 
@@ -55,4 +48,3 @@ Improvements listed below might come out in a month, a year, or (unfortunately) 
 Talk to us! These plans are formed based on an overall understanding of user needs and the team vision.
 Feedback can alter either of these, which will then lead to changes in plans.
 You can either contact us via [list of ways to contact, including links].
-

--- a/activities/supporting-codebase-governance/technical-roadmap-template.md
+++ b/activities/supporting-codebase-governance/technical-roadmap-template.md
@@ -19,16 +19,7 @@ They will change when relevant information is absorbed by the team.
 
 ## What is currently being worked on
 
-*Not all sections need to be filled in, but the title and why are recommended. The list can have any number of items.*
-You can add new items by adding a heading for the title, why, how, and what.
-
-### [Technical thing name or title X]
-
-#### Why X
-
-#### How to make X
-
-#### What X is
+*Add a heading for everything is currently worked on here. Follow that heading with why you're working on that. Optionally you can also describe the how and what.*
 
 ## Themes that will likely be worked on next
 

--- a/activities/supporting-codebase-governance/technical-roadmap-template.md
+++ b/activities/supporting-codebase-governance/technical-roadmap-template.md
@@ -26,13 +26,7 @@ They will change when relevant information is absorbed by the team.
 These are the plans that currently feel like the best options for what the team should work on next.
 Improvements listed below might come out in a month, a year, or (unfortunately) never — it all depends what the team learns along the way.
 
-### [Technical thing name or title Y]
-
-#### Why Y
-
-#### How to make Y
-
-#### What Y is
+*Add a heading for everything that is likely to be worked on in the future here. Follow that heading with why you're working on that. Optionally you can also describe the how and what.*
 
 ## How can I affect these plans
 

--- a/activities/supporting-codebase-governance/technical-roadmap-template.md
+++ b/activities/supporting-codebase-governance/technical-roadmap-template.md
@@ -22,12 +22,19 @@ They will change when relevant information is absorbed by the team.
 *Not all sections need to be filled in, but the title and why are recommended.*
 
 ### Technical thing 1
+
 #### Why 1
+
 #### How 1
+
 #### What 1
+
 ### Technical thing 2
+
 #### Why 2
+
 #### How 2
+
 #### What 2
 
 ## Themes that will likely be worked on next
@@ -36,11 +43,14 @@ These are the plans that currently feel like the best options for what the team 
 Improvements listed below might come out in a month, a year, or (unfortunately) never — it all depends what the team learns along the way.
 
 ### Technical thing 3
+
 #### Why 3
+
 #### How 3
+
 #### What 3
 
-## How can I affect these plans?
+## How can I affect these plans
 
 Talk to us! These plans are formed based on an overall understanding of user needs and the team vision.
 Feedback can alter either of these, which will then lead to changes in plans.

--- a/activities/supporting-codebase-governance/technical-roadmap-template.md
+++ b/activities/supporting-codebase-governance/technical-roadmap-template.md
@@ -19,29 +19,29 @@ They will change when relevant information is absorbed by the team.
 
 ## What is currently being worked on
 
-*Not all sections need to be filled in, but the title and why are recommended.*
+*Not all sections need to be filled in, but the title and why are recommended. The list can have any number of items.*
 You can add new items by adding a heading for the title, why, how, and what.
 
-### [Technical thing name or title]
+### [Technical thing name or title X]
 
-#### Why
+#### Why X
 
-#### How
+#### How to make X
 
-#### What
+#### What X is
 
 ## Themes that will likely be worked on next
 
 These are the plans that currently feel like the best options for what the team should work on next.
 Improvements listed below might come out in a month, a year, or (unfortunately) never — it all depends what the team learns along the way.
 
-### [Technical thing name or title]
+### [Technical thing name or title Y]
 
-#### Why 3
+#### Why Y
 
-#### How 3
+#### How to make Y
 
-#### What 3
+#### What Y is
 
 ## How can I affect these plans
 

--- a/activities/supporting-codebase-governance/technical-roadmap-template.md
+++ b/activities/supporting-codebase-governance/technical-roadmap-template.md
@@ -35,7 +35,7 @@ You can add new items by adding a heading for the title, why, how, and what.
 These are the plans that currently feel like the best options for what the team should work on next.
 Improvements listed below might come out in a month, a year, or (unfortunately) never — it all depends what the team learns along the way.
 
-### Technical thing 3
+### [Technical thing name or title]
 
 #### Why 3
 

--- a/activities/supporting-codebase-governance/technical-roadmap-template.md
+++ b/activities/supporting-codebase-governance/technical-roadmap-template.md
@@ -1,0 +1,48 @@
+---
+tags: Templates
+---
+
+# Technical Roadmap Template
+
+This is a template that can be used for technical roadmaps, it's based on a version that [Sharetribe used](https://github.com/sharetribe/sharetribe/blob/a029d02ab3b60009ebb6faff54117ba1034a6bfc/TECHNICAL_ROADMAP.md).
+
+## Overview
+
+This document sheds light on the current development plans of the team.
+Plans change constantly as new information comes to light.
+Thus, this document represents **a snapshot of our plans at this point in time**, based on the information that is currently available.
+
+In other words, the purpose of this document is to share the current state of the team's understanding.
+
+To reiterate: the plans shared in this document should not be considered set in stone.
+They will change when relevant information is absorbed by the team.
+
+## What is currently being worked on
+
+*Not all sections need to be filled in, but the title and why are recommended.*
+
+### Technical thing 1
+#### Why 1
+#### How 1
+#### What 1
+### Technical thing 2
+#### Why 2
+#### How 2
+#### What 2
+
+## Themes that will likely be worked on next
+
+These are the plans that currently feel like the best options for what the team should work on next.
+Improvements listed below might come out in a month, a year, or (unfortunately) never — it all depends what the team learns along the way.
+
+### Technical thing 3
+#### Why 3
+#### How 3
+#### What 3
+
+## How can I affect these plans?
+
+Talk to us! These plans are formed based on an overall understanding of user needs and the team vision.
+Feedback can alter either of these, which will then lead to changes in plans.
+You can either contact us via [list of ways to contact, including links].
+


### PR DESCRIPTION
Adding a template for a technical roadmap

-----
[View rendered activities/supporting-codebase-governance/index.md](https://github.com/publiccodenet/about/blob/add-roadmap-template/activities/supporting-codebase-governance/index.md)
[View rendered activities/supporting-codebase-governance/technical-roadmap-template.md](https://github.com/publiccodenet/about/blob/add-roadmap-template/activities/supporting-codebase-governance/technical-roadmap-template.md)