### PR TITLE
Specify a long timeout to the htmlproofer tests and exclude rate limited requests

### DIFF
--- a/script/test.sh
+++ b/script/test.sh
@@ -13,9 +13,11 @@ bundle exec jekyll build
 # jekyll does not require extentions like HTML
 # ignore edit links to GitHub as they might not exist yet and
 # set an extra long timout for test-servers with poor connectivity
+# ignore request rate limit errors (HTTP 429) which often come from Twitter or GitHub
 # using the files in Jekylls build folder
 bundle exec htmlproofer \
     --assume-extension \
     --url-ignore "/github.com/(.*)/edit/" \
     --typhoeus-config '{"timeout":60,"ssl_verifypeer":false,"ssl_verifyhost":"0"}' \
+    --http_status_ignore "429" \
     ./_site

--- a/script/test.sh
+++ b/script/test.sh
@@ -9,7 +9,13 @@ bundle exec mdl -r ~MD013,~MD029 -i -g '.'
 # Build the site
 bundle exec jekyll build
 
-# Check for broken links and missing alt tags, 
+# Check for broken links and missing alt tags: 
+# jekyll does not require extentions like HTML
 # ignore edit links to GitHub as they might not exist yet and
 # set an extra long timout for test-servers with poor connectivity
-bundle exec htmlproofer --assume-extension --url-ignore "/github.com/(.*)/edit/" ./_site --typhoeus-config '{"timeout":60}'
+# using the files in Jekylls build folder
+bundle exec htmlproofer \
+    --assume-extension \
+    --url-ignore "/github.com/(.*)/edit/" \
+    --typhoeus-config '{"timeout":60,"ssl_verifypeer":false,"ssl_verifyhost":"0"}' \
+    ./_site

--- a/script/test.sh
+++ b/script/test.sh
@@ -12,4 +12,4 @@ bundle exec jekyll build
 # Check for broken links and missing alt tags, 
 # ignore edit links to GitHub as they might not exist yet and
 # set an extra long timout for test-servers with poor connectivity
-bundle exec htmlproofer --assume-extension --url-ignore "/github.com/(.*)/edit/" ./_site --typhoeus-config '{"timeout":15}'
+bundle exec htmlproofer --assume-extension --url-ignore "/github.com/(.*)/edit/" ./_site --typhoeus-config '{"timeout":60}'

--- a/script/test.sh
+++ b/script/test.sh
@@ -9,5 +9,7 @@ bundle exec mdl -r ~MD013,~MD029 -i -g '.'
 # Build the site
 bundle exec jekyll build
 
-# Check for broken links and missing alt tags, ignore edit links to GitHub as they might not exist yet
-bundle exec htmlproofer --assume-extension --url-ignore "/github.com/(.*)/edit/" ./_site
+# Check for broken links and missing alt tags, 
+# ignore edit links to GitHub as they might not exist yet and
+# set an extra long timout for test-servers with poor connectivity
+bundle exec htmlproofer --assume-extension --url-ignore "/github.com/(.*)/edit/" ./_site --typhoeus-config '{"timeout":15}'


### PR DESCRIPTION
A lot of HTTP requests are failing to return to the
continuous integration server in time leading to failed tests.

HTMLproofer enables overriding the default timeout for Typheous,
The Ruby libcurl library it uses.

Setting the timeout to 60 seconds is more than enough
and seems to have little impact on build time.

Twitter and Github can throw 429 error when too many requests are sent.
This can come from our tests happening concurrently or other testing
happening on the same IP address.

If a rate limiting error is thrown it can be assumed that this
resource exists over that it is broken.

I've tried it 25 times on Travis and all passed.
I've copied @felixfaassen's solution for SSL.
