### PR TITLE
Remove hyperlinks to Foundation profile on StackOverflow Jobs

### DIFF
--- a/activities/recruitment/hiring-process.md
+++ b/activities/recruitment/hiring-process.md
@@ -19,8 +19,10 @@ We also use the current team's network to spread awareness of the job opening (v
 
 * [t9t.io open source jobs board](https://oo.t9t.io/jobs)
 * [fossjobs.net open source jobs board](https://www.fossjobs.net/)
-* [StackOverflow Jobs](https://stackoverflow.com/jobs/companies/foundation-for-public-code)
+* StackOverflow Jobshttps://stackoverflow.com/jobs
 * LinkedIn page for Foundation for Public Code
+
+Between summer 2019 and summer 2020, most of our new hires found out about us on LinkedIn.
 
 ## Processing reactions of people expressing interest
 

--- a/activities/recruitment/hiring-process.md
+++ b/activities/recruitment/hiring-process.md
@@ -19,10 +19,10 @@ We also use the current team's network to spread awareness of the job opening (v
 
 * [t9t.io open source jobs board](https://oo.t9t.io/jobs)
 * [fossjobs.net open source jobs board](https://www.fossjobs.net/)
-* StackOverflow Jobshttps://stackoverflow.com/jobs
+* [StackOverflow Jobs](https://stackoverflow.com/jobs)
 * LinkedIn page for Foundation for Public Code
 
-Between summer 2019 and summer 2020, most of our new hires found out about us on LinkedIn.
+Between summer 2019 and summer 2020, most of our new hires discovered us through LinkedIn job ads.
 
 ## Processing reactions of people expressing interest
 

--- a/activities/recruitment/index.md
+++ b/activities/recruitment/index.md
@@ -14,7 +14,6 @@ These are the resources and processes used for recruitment:
 For possible applicants:
 
 * [Careers section with open positions on the homepage](https://publiccode.net/careers/)
-* [Our Stack Overflow organization page](https://stackoverflow.com/jobs/companies/foundation-for-public-code)
 
 See also:
 


### PR DESCRIPTION
Our company StackOverflow Jobs profile has been taken down, presumably because we don't have active jobs advertized with them at the moment. I've removed the links from About.

-----
[View rendered activities/recruitment/hiring-process.md](https://github.com/publiccodenet/about/blob/broken-stack-overflow/activities/recruitment/hiring-process.md)
[View rendered activities/recruitment/index.md](https://github.com/publiccodenet/about/blob/broken-stack-overflow/activities/recruitment/index.md)