### PR TITLE
Soften stance on press releases in communications plan

### DIFF
--- a/activities/communication/communications-plan.md
+++ b/activities/communication/communications-plan.md
@@ -136,15 +136,15 @@ Scheduling days of the week for maximum engagement:
 
 ### Press releases
 
-We rarely create press releases -  usually our news should be available to everyone at the same time. Instead, we prefer to:
+We rarely create press releases - we believe our news should usually be available to everyone at the same time. Instead, we prefer to:
 
-* publish our own news in blogposts
+* publish our news in blogposts
 * link and share our members' or others' news stories and press releases
 
 When we have a press release, we:
 
 * send it embargoed to press outlets via email first
-* on the scheduled date, publish it on our blog as news
+* publish it on our blog as news on the scheduled date
 
 ## Tone of voice
 

--- a/activities/communication/communications-plan.md
+++ b/activities/communication/communications-plan.md
@@ -136,10 +136,15 @@ Scheduling days of the week for maximum engagement:
 
 ### Press releases
 
-We don't publish press releases at the moment. Instead, we:
+We rarely create press releases -  usually our news should be available to everyone at the same time. Instead, we prefer to:
 
 * publish our own news in blogposts
-* link to our members' news stories and press releases
+* link and share our members' or others' news stories and press releases
+
+When we have a press release, we:
+
+* send it embargoed to press outlets via email first
+* on the scheduled date, publish it on our blog as news
 
 ## Tone of voice
 


### PR DESCRIPTION
Since we're planning our first press release, our communications plan shouldn't say we don't do press releases.

-----
[View rendered activities/communication/communications-plan.md](https://github.com/publiccodenet/about/blob/press-releases/activities/communication/communications-plan.md)