### PR TITLE
Add stub SDGs content

### DIFF
--- a/activities/value-and-impact/index.md
+++ b/activities/value-and-impact/index.md
@@ -8,3 +8,4 @@ These are all the activities, documents and templates for value and impact:
 
 * [User mapping and value proposition hypotheses](user-mapping/index.md) for potential users of Foundation for Public Code products and activities
 * [Existing pain points](pain-points/index.md) for users of the Foundation for Public Code products and activities
+* [How public code supports the Sustainable Development Goals](sustainable-development-goals.md)

--- a/activities/value-and-impact/sustainable-development-goals.md
+++ b/activities/value-and-impact/sustainable-development-goals.md
@@ -1,0 +1,12 @@
+---
+type: resource
+---
+
+# How public code supports the Sustainable Development Goals
+
+To illustrate the impact of a healthy public code ecosystem on basis of the United Nation's [Sustainable Development Goals](https://sdgs.un.org/goals), we contribute towards:
+
+* goal 16, ‘Peace, Justice, and Strong Institutions’: with transparency, quality public service delivery and participation
+* goal 11, ‘Sustainable Cities and Communities’: by enabling sustainable collaboration on digital transformation at scale
+* goal 9, ‘Industry, Innovation, and Infrastructure’: by enabling new collaborations between public and private parties
+* goal 17, ‘Partnerships for the Goals’: by building networks and making tools available

--- a/activities/value-and-impact/user-mapping/index.md
+++ b/activities/value-and-impact/user-mapping/index.md
@@ -31,4 +31,3 @@ Other interested parties:
 
 * end users (residents and citizens)
 * journalists and academia
-

--- a/activities/value-and-impact/user-mapping/senior-civil-servants.md
+++ b/activities/value-and-impact/user-mapping/senior-civil-servants.md
@@ -20,6 +20,7 @@ Positive reasons for why they might be interested in our work:
 * enlarging communities of practice and share resources
 * facilitating re-approachability/reusability/maintenance
 * building trust and security in public services and underlying technology
+* public code is a way to [fulfill their Sustainable Development Goals](../sustainable-development-goals.md) commitments
 
 Negative reasons for why they might be interested in our work:
 


### PR DESCRIPTION
Closes #572.

This is a draft PR pending consultation with @ainali about how much of the [additional SDGs content](https://hackmd.io/2ZknOPyUSKWSI5S324UhEQ?both) he's written makes sense to put in a blogpost vs here.

I believe that our About content should be ready to use as rock solid, evidenced talking points by our stakeholders. Points where we make an ambient contribution may be better put into a blogpost. I'd prefer we offer fewer, better arguments.

-----
[View rendered activities/value-and-impact/index.md](https://github.com/publiccodenet/about/blob/sdgs/activities/value-and-impact/index.md)
[View rendered activities/value-and-impact/sustainable-development-goals.md](https://github.com/publiccodenet/about/blob/sdgs/activities/value-and-impact/sustainable-development-goals.md)
[View rendered activities/value-and-impact/user-mapping/index.md](https://github.com/publiccodenet/about/blob/sdgs/activities/value-and-impact/user-mapping/index.md)
[View rendered activities/value-and-impact/user-mapping/senior-civil-servants.md](https://github.com/publiccodenet/about/blob/sdgs/activities/value-and-impact/user-mapping/senior-civil-servants.md)