### PR TITLE
Add link to Standard maintenance activity

### DIFF
--- a/activities/index.md
+++ b/activities/index.md
@@ -18,6 +18,7 @@ Activities that support the above as well as make staff operations work:
 * [Documentation](documentation/index.md)
 * [Events](events/index.md)
 * [Explaining codebase stewardship](explaining-codebase-stewardship/index.md)
+* [Maintenance of the Standard for Public Code](standard-maintenance/index.md)
 * [Member relations](member-relations/index.md)
 * [Membership growth](membership-growth/index.md)
 * [Office management](office-management/index.md)

--- a/activities/standard-maintenance/index.md
+++ b/activities/standard-maintenance/index.md
@@ -6,8 +6,8 @@ type: index
 
 The Foundation for Public Code and its codebase stewards maintain the [Standard for Public Code](https://standard.publiccode.net).
 
-As a part of the we:
+As a part of maintaining the Standard for Public Code we:
 
 * [Organize community calls](community-call.md)
-* [Prepare community calls](preparing-community-call.md)
-* [Run community calls](running-community-call.md)
+   * [Prepare community calls](preparing-community-call.md)
+   * [Run community calls](running-community-call.md)

--- a/activities/standard-maintenance/index.md
+++ b/activities/standard-maintenance/index.md
@@ -9,5 +9,5 @@ The Foundation for Public Code and its codebase stewards maintain the [Standard 
 As a part of maintaining the Standard for Public Code we:
 
 * [Organize community calls](community-call.md)
-   * [Prepare community calls](preparing-community-call.md)
-   * [Run community calls](running-community-call.md)
+* [Prepare community calls](preparing-community-call.md)
+* [Run community calls](running-community-call.md)


### PR DESCRIPTION
And adding missing words
Fixes #701

-----
[View rendered activities/index.md](https://github.com/publiccodenet/about/blob/standard-maintenance/activities/index.md)
[View rendered activities/standard-maintenance/index.md](https://github.com/publiccodenet/about/blob/standard-maintenance/activities/standard-maintenance/index.md)