### PR TITLE
Update broken 'advertise maturity' link in Standard to current 'document maturity'

### DIFF
--- a/activities/codebase-auditing/review-template.md
+++ b/activities/codebase-auditing/review-template.md
@@ -175,7 +175,7 @@ Contributions SHOULD pass automated tests on style. |  |
 Your codebase SHOULD include inline comments and documentation for non-trivial sections. |  |
 You MAY include sections in your style guide on understandable English. |  |
 
-## [Pay attention to codebase maturity](https://standard.publiccode.net/criteria/advertise-maturity.html)
+## [Document codebase maturity](https://standard.publiccode.net/criteria/document-maturity.html)
 
 - [ ] compliant with this criterion.
 


### PR DESCRIPTION
Travis will block everything until this is fixed.
This complements [Standard issue 407](https://github.com/publiccodenet/standard/issues/407) to add a redirect for this dead link.

-----
[View rendered activities/codebase-auditing/review-template.md](https://github.com/publiccodenet/about/blob/fix-advertise-maturity/activities/codebase-auditing/review-template.md)