### PR TITLE
Pin HTML-Proofer to 3.17

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 gem 'github-pages', group: :jekyll_plugins
-gem 'html-proofer'
+gem 'html-proofer', "3.17"
 gem 'mdl'
 gem "faraday", "~> 0.17"


### PR DESCRIPTION
Version 3.17.1 broke internal links.
This is a temporary fix until that is fixed.
https://github.com/gjtorikian/html-proofer/issues/595