### PR TITLE
removed reference to migration

### DIFF
--- a/activities/tool-management/odoo.md
+++ b/activities/tool-management/odoo.md
@@ -16,6 +16,8 @@ We offer training to new staff.
 
 ## Odoo management
 
+Our service provider is OpenWorx.
+
 The Operations coordinator takes care of user administration, reports bugs and is the contact person for the service provider.
 
 ## Privacy and GDPR

--- a/activities/tool-management/odoo.md
+++ b/activities/tool-management/odoo.md
@@ -16,8 +16,6 @@ We offer training to new staff.
 
 ## Odoo management
 
-Odoo Community is currently hosted and maintained by a service provider in the UK. We are migrating our instance to Openworx in November 2020.
-
 The Operations coordinator takes care of user administration, reports bugs and is the contact person for the service provider.
 
 ## Privacy and GDPR


### PR DESCRIPTION
I removed the reference to the migration from UK provider to Dutch provider

-----
[View rendered activities/tool-management/odoo.md](https://github.com/publiccodenet/about/blob/update-odoo-2020/activities/tool-management/odoo.md)