### PR TITLE
Remove reference to Discourse

### DIFF
--- a/activities/tool-management/tool-and-email-naming-conventions.md
+++ b/activities/tool-management/tool-and-email-naming-conventions.md
@@ -43,7 +43,6 @@ These tools have their own URL and associated email:
 * client relationship management: odoo.publiccode.net (Odoo)
 * internal chat: chat.publiccode.net (Mattermost)
 * file sharing: collaboration.publiccode.net (Nextcloud)
-* forum: discuss.publiccode.net (Discourse)
 * video calling: meet.publiccode.net (Jitsi)
 
 ## Email address uses and formatting


### PR DESCRIPTION
Fixes #763

-----
[View rendered activities/tool-management/tool-and-email-naming-conventions.md](https://github.com/publiccodenet/about/blob/ja-remove-discourse/activities/tool-management/tool-and-email-naming-conventions.md)