### PR TITLE
Pin chef-utils for travis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 gem 'github-pages', group: :jekyll_plugins
 gem 'html-proofer', "3.17"
+gem 'chef-utils', "16.6.14"
 gem 'mdl'
 gem "faraday", "~> 0.17"


### PR DESCRIPTION
chef-utils-16.9.17 requires ruby version >= 2.6.0,
travis provides ruby 2.5.3p105