### PR TITLE
reorder release checklist to reflect common practice

### DIFF
--- a/activities/documentation/merge-develop-into-master.md
+++ b/activities/documentation/merge-develop-into-master.md
@@ -14,17 +14,17 @@ The purpose of routinely merging develop into master is to make sure our website
 1. Create a 'release branch' from 'develop', naming it '[date]+release'.
 2. Create a pull request from release branch into master.
 3. Include 'review checklist template' below as a comment on your pull request.
-3. Review all changes and additions. Small uncontroversial problems, such as typos, can be fixed in the release branch. For larger and/or controversial problems (such as restructuring of context), create a new branch and make a pull request into the release branch. For any open ended issues (such as new content suggestions), create an issue.
-4. Once review is complete, merge to master! :tada:
+4. Review all changes and additions. Small uncontroversial problems, such as typos, can be fixed in the release branch. For larger and/or controversial problems (such as restructuring of context), create a new branch and make a pull request into the release branch. For any open ended issues (such as new content suggestions), create an issue.
+5. Once review is complete, merge to master! :tada:
 
 Our publishing process is [based on GitFlow](https://datasift.github.io/gitflow/IntroducingGitFlow.html).
 
 ```
 ## Review checklist template
 
-- [ ] Correct Markdown and formatting
 - [ ] All new files are linked in indices
 - [ ] Front matter is present and correct
 - [ ] Bullets and numbered lists are correct
+- [ ] Correct Markdown and formatting
 - [ ] All content reviewed
 ```


### PR DESCRIPTION
In years of using the About release checklist, I've discovered I find it easier to go from checking easy, binary things to the larger, more subjective. I've reordered this list to reflect this progression.

-----
[View rendered activities/documentation/merge-develop-into-master.md](https://github.com/publiccodenet/about/blob/reflect-usage-practice-in-guidance/activities/documentation/merge-develop-into-master.md)