### PR TITLE
Community call introductions with reasons

### DIFF
--- a/activities/standard-maintenance/preparing-community-call.md
+++ b/activities/standard-maintenance/preparing-community-call.md
@@ -16,7 +16,7 @@ Together with the codebase stewards figure out if there is anything specific you
 ### Templated agenda items
 
 1. Opening the call
-  * Introduction round (all)
+  * Everyone introduces themselves and why they are in this call (all)
   * Short update from the Foundation for Public Code (chair)
 2. Substance of the call
 


### PR DESCRIPTION
If people tell everyone what they are willing to bring and wanting to get from a call it enables everyone to connect based on each other's incentives.

In addition to that it enables us to go through this ritual meaningfully if there are no others on the call that are new.

-----
[View rendered activities/standard-maintenance/preparing-community-call.md](https://github.com/publiccodenet/about/blob/introduce-your-intentions/activities/standard-maintenance/preparing-community-call.md)