### PR TITLE
Enable internal link checking

### DIFF
--- a/script/test-without-link-check.sh
+++ b/script/test-without-link-check.sh
@@ -11,13 +11,9 @@ bundle exec jekyll build
 
 # Check for broken links and missing alt tags:
 # jekyll does not require extentions like HTML
-# run only "ScriptCheck" and "ImageCheck"; skip "LinkCheck"
-# set an extra long timout for test-servers with poor connectivity
-# ignore request rate limit errors (HTTP 429)
+#  --disable-external to only check internal links
 # using the files in Jekylls build folder
 bundle exec htmlproofer \
     --assume-extension \
-    --checks-to-ignore LinkCheck \
-    --typhoeus-config '{"timeout":60,"ssl_verifypeer":false,"ssl_verifyhost":"0"}' \
-    --http_status_ignore "429" \
+    --disable-external \
     ./_site


### PR DESCRIPTION
Enable link checking of internal links only with the "--disable-externl"
commandline option which sets the "disable_external" flag, thus skipping
the link checker on external links.