### PR TITLE
Mdl 2021 03 24

### DIFF
--- a/activities/communication/communication-remote-first.md
+++ b/activities/communication/communication-remote-first.md
@@ -25,11 +25,13 @@ While this loop is easily closed in a co-located working environment (reach over
 Several ways to mitigate this could include developing a culture around:
 
 As an initiator:
+
 * Set a deadline for responses, and signal what you will do after that deadline (move ahead, or stop working on it if no other interest,...) 
 * Signal clearly if/when this is a blocker to your work that prevents you from moving on
 * Where possible, ask individuals for input over an undefined group 
 * Where possible, provide clear context, aims and expectations around the request
 
 As a responder:
+
 * Don't deprioritize with silence, but actively say you can't/won't prioritize something
 * When you take on an open request, try signaling whether it is something you will prioritize, or something you will only do *if* you have time and space

--- a/script/test-without-link-check.sh
+++ b/script/test-without-link-check.sh
@@ -2,16 +2,9 @@
 set -e # halt script on error
 
 # Lint markdown using the Markdownlint gem with the default ruleset except for:
-# MD007 Unordered list indentation: we allow sub-lists to also have bullets
 # MD013 Line length: we allow long lines
 # MD029 Ordered list item prefix: we allow lists to be sequentially numbered
-#
-# Additionally, we have these violations which should be resolved:
-# MD026 Trailing punctuation in header
-# MD032 Lists should be surrounded by blank lines
-# MD034 Bare URL used
-#
-bundle exec mdl -r ~MD007,~MD013,~MD029,~MD026,~MD032,~MD034 -i -g '.'
+bundle exec mdl -r ~MD013,~MD029 -i -g '.'
 
 # Build the site
 bundle exec jekyll build


### PR DESCRIPTION
* Make markdown "linter" more strict
* Markdown fix: Lists should be surrounded by blank lines

-----
[View rendered activities/communication/communication-remote-first.md](https://github.com/publiccodenet/about/blob/mdl-2021-03-24/activities/communication/communication-remote-first.md)