### PR TITLE
Fix internal link guest-selection-criteria

### DIFF
--- a/activities/live-streaming/prepare-live-stream.md
+++ b/activities/live-streaming/prepare-live-stream.md
@@ -11,7 +11,7 @@ When setting up a new [live stream](index.md) for 'Let's talk about public code'
 
 1. Decide who will be the next guest
    1. In [Odoo](../tool-management/odoo.md) we have a project "Let's talk about public code" with `Ideas`
-   2. Discuss in the team who would fit as a guest (based on [guest selection criteria](live-streaming#guest-selection-criteria)) in the near future and take contact with them
+   2. Discuss in the team who would fit as a guest (based on [guest selection criteria](../live-streaming/index.md#guest-selection-criteria)) in the near future and take contact with them
    3. If the guest is agrees, move them to `Preplanning`
    4. Decide the date and time of a stream and move the card to `Next episode`
 2. Prepare questions for the interview in a HackMD shared with all interviewers


### PR DESCRIPTION
As @bvhme predicted, broken *internal* links are a likely failure scenario, thus we should to merge [Enable internal link checking #899](https://github.com/publiccodenet/about/pull/899) to catch these types of errors earlier.