### PR TITLE
Use "contribute" instead of "join"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 ---
 type: Guide
-explains: ways in which people and organizations can join the Foundation for Public Code
+explains: ways in which people and organizations can contribute to the Foundation for Public Code
 ---
 
-# Join us
+# Contribute to our community
 
 Thanks for your interest in the Foundation for Public Code! We’re excited to meet you.
 


### PR DESCRIPTION
"Join us" could be misleading and make visitors think they are being redirected to the jobs site.
In my opinion "Contribute to our community", "Become part of our community" or even just "Contribute" would be more accurate.

-----
[View rendered CONTRIBUTING.md](https://github.com/publiccodenet/about/blob/contribute-vs-join/CONTRIBUTING.md)