### PR TITLE
Add Stack Overflow company blurb to activities/recruitment

### DIFF
--- a/activities/recruitment/company-description.md
+++ b/activities/recruitment/company-description.md
@@ -4,7 +4,7 @@ type: resource
 
 # Company description for job advertising websites
 
-> Written initially for Stack Overflow (using their subheadings), this can be reused or remixed elsewhere.
+> Written initially for Stack Overflow Jobs (using their subheadings), this can be reused or remixed elsewhere.
 
 ## About Foundation for Public Code
 
@@ -21,7 +21,7 @@ We do this through active codebase stewardship and by publishing the [Standard f
 
 ### How we work
 
-All of us fundamentally believe that our public organizations using FOSS will result in better public services for everyone and be a better use of taxpayer money. We do impactful work as part of a mission we believe in.
+All of us fundamentally believe that our public organizations using free and open source software (FOSS) will result in better public services for everyone and be a better use of taxpayer money. We do impactful work as part of a mission we believe in.
 
 We're small, open, flexible and non-hierarchical. We act with integrity and compassion towards each other and the broader communities we're a part of. We make decisions by rough consensus, and value the diversity of perspectives on our team.
 
@@ -34,7 +34,7 @@ We're ambitious but humble - we sincerely want this to succeed, but there's no g
 ### Benefits
 
 * 25 days of paid leave plus an average of 6 public holidays
-* enthusiastic BYOD culture
+* enthusiastic bring your own device (BYOD) culture
 * flexible work environment
 * friendly, motivating and sincere atmosphere
 * highly skilled international colleagues and collaborators

--- a/activities/recruitment/company-description.md
+++ b/activities/recruitment/company-description.md
@@ -1,0 +1,43 @@
+---
+type: resource
+---
+
+# Company description for job advertising websites
+
+> Written initially for Stack Overflow (using their subheadings), this can be reused or remixed elsewhere.
+
+## About Foundation for Public Code
+
+We aim to build international public sector communities working together to share open source software and policy in a radically collaborative and open way. Public organizations are building more open software than ever before, but collaborating at the scale needed to co-develop and maintain a codebase is still hard - it's not the core responsibility of any single public organization.
+
+The Foundation for Public Code was set up to plug this infrastructure gap so that people already working for the public good can more easily:
+
+* Find transformative codebases to reuse
+* Design their code in a way that encourages international reuse
+* Build thriving open source communities around their codebases
+* Get institutional support in navigating the risk and procurement hurdles to using open source for public services and infrastructure
+
+We do this through active codebase stewardship and by publishing the [Standard for Public Code](https://standard.publiccode.net/).
+
+### How we work
+
+All of us fundamentally believe that our public organizations using FOSS will result in better public services for everyone and be a better use of taxpayer money. We do impactful work as part of a mission we believe in.
+
+We're small, open, flexible and non-hierarchical. We act with integrity and compassion towards each other and the broader communities we're a part of. We make decisions by rough consensus, and value the diversity of perspectives on our team.
+
+We hire the best people we can, trust their expertise, and give them near infinite autonomy. We also support each other, and do lots of pair working.
+
+Because nobody has ever done this before for government and we've just started, everything we're doing is greenfield - everyone here comes to work every day knowing that what they'll do that day will meaningfully shape the Foundation's future.
+
+We're ambitious but humble - we sincerely want this to succeed, but there's no guarantee. Because we believe that failure is the best teacher, we encourage curiosity, experimentation and learning.
+
+### Benefits
+
+* 25 days of paid leave plus an average of 6 public holidays
+* enthusiastic BYOD culture
+* flexible work environment
+* friendly, motivating and sincere atmosphere
+* highly skilled international colleagues and collaborators
+* work in the center of Amsterdam
+* easily accessible by public transport
+* organic coffee, tea and fruit

--- a/activities/recruitment/company-description.md
+++ b/activities/recruitment/company-description.md
@@ -6,7 +6,7 @@ type: resource
 
 > Written initially for Stack Overflow Jobs (using their subheadings), this can be reused or remixed elsewhere.
 
-## About Foundation for Public Code
+## About the Foundation for Public Code
 
 We aim to build international public sector communities working together to share open source software and policy in a radically collaborative and open way. Public organizations are building more open software than ever before, but collaborating at the scale needed to co-develop and maintain a codebase is still hard - it's not the core responsibility of any single public organization.
 

--- a/activities/recruitment/index.md
+++ b/activities/recruitment/index.md
@@ -10,6 +10,7 @@ These are the resources and processes used for recruitment:
 
 * [Process for recruiting and hiring candidates](hiring-process.md)
 * [Open position advertisement template](open-position-template.md)
+* [Company description for job advertising websites](company-description.md)
 
 Resources for possible applicants:
 


### PR DESCRIPTION
So that I can share it with potential applicants for the [communications editor/storyteller](https://publiccode.net/careers/content-editor.html) role.

-----
[View rendered activities/recruitment/company-description.md](https://github.com/publiccodenet/about/blob/add-Stack-Overflow-company-description/activities/recruitment/company-description.md)
[View rendered activities/recruitment/index.md](https://github.com/publiccodenet/about/blob/add-Stack-Overflow-company-description/activities/recruitment/index.md)