### PR TITLE
Unpin dependency gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 gem 'github-pages', group: :jekyll_plugins
 gem 'html-proofer'
-gem 'chef-utils', "16.6.14"
+gem 'chef-utils'
 gem 'mdl'
 gem "faraday"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 gem 'github-pages', group: :jekyll_plugins
-gem 'html-proofer', "3.17"
+gem 'html-proofer'
 gem 'chef-utils', "16.6.14"
 gem 'mdl'
-gem "faraday", "~> 0.17"
+gem "faraday"


### PR DESCRIPTION
We had pinned these to specific versions, this no longer seems necessary.