### PR TITLE
Explain 'open, unless' more

### DIFF
--- a/activities/communication/communication-principles.md
+++ b/activities/communication/communication-principles.md
@@ -8,7 +8,7 @@ The Foundation For Public Code itself is open source.
 
 Our communication principles are:
 
-* open, unless
+* open, unless: open by default, unless you can explain why it needs to be closed
 * invites contributions by all
 * clearly explained
 * hypertextual, web first


### PR DESCRIPTION
I've used explain:

* the articulation is important for all stakeholders to understand
* the ability to defend the choice is important

I've used closed:

* because secret is only about secrecy not about not being open to input
* as the opposition to open

Fixes #264

-----
[View rendered activities/communication/communication-principles.md](https://github.com/publiccodenet/about/blob/explain-open-unless/activities/communication/communication-principles.md)