### PR TITLE
Add (merging develop into main) to link

### DIFF
--- a/activities/documentation/index.md
+++ b/activities/documentation/index.md
@@ -27,6 +27,6 @@ In order to make it easier to navigate and contribute information we try to limi
 * [How to write an index](writing-indexes.md)
 * [File name convention in About](about-file-names.md)
 * [Folder structure of About](about-folder-structure.md)
-* [How to publish on About](merge-develop-into-main.md)
+* [How to publish on About (merging develop into main)](merge-develop-into-main.md)
 
 See also our [trainings](../trainings/index.md), which have tips on Github, issues, and more.


### PR DESCRIPTION
The title of the guide has this extra bit on the title that makes it a lot clearer to what the guide is, I suggest adding it.

-----
[View rendered activities/documentation/index.md](https://github.com/publiccodenet/about/blob/add-merge-name/activities/documentation/index.md)