### PR TITLE
Remove openzaak specific sentence

### DIFF
--- a/activities/supporting-codebase-governance/index.md
+++ b/activities/supporting-codebase-governance/index.md
@@ -18,7 +18,7 @@ Codebase governance is strictly limited to the codebase. The governance of the c
 
 Governance of implementations is whatever contextual arrangement is made to enable a local implementaiton. This can include contracting of marketing parties, collective procurements, or service agreements between municipal departments. For example, this could include a joint procurement by several municipalities, coordinated by an association of municipalities, for a consortium of market parties (including development, maintainenance and hosting parties).
 
-Governance of implementations can vary strongly, ranging from one municipality who does everything in house, to municipalities who interact with a single market party for all their needs and questions. The market consultation is part of defining what these relationships should or could look like.
+Governance of implementations can vary strongly, ranging from one municipality who does everything in house, to municipalities who interact with a single market party for all their needs and questions.
 
 Below is a visual representation summarizing the information above.
 


### PR DESCRIPTION
This sentence was to written to help situate openzaak market consultation participants. It's not harmful now, but a bit confusing, as it's the only reference to a market consultation. Market consultations are also not necessary in the governance of implementations.

-----
[View rendered activities/supporting-codebase-governance/index.md](https://github.com/publiccodenet/about/blob/Remove-openzaak-specific-sentence/activities/supporting-codebase-governance/index.md)