### PR TITLE
Guidance on adding Markdown templates to resources

### DIFF
--- a/activities/documentation/writing-resources.md
+++ b/activities/documentation/writing-resources.md
@@ -35,6 +35,22 @@ Followed by the name of the resource:
 
 Followed by the content of the resource.
 
+#### Adding templates
+
+For templates you can use code blocks. You can make a Markdown codeblock opened by:
+
+````markdown
+```markdown
+````
+
+and closed by:
+
+````markdown
+```
+````
+
+By using curly braces `{` and `}` you can clearly indicate where things need to be filled in whilst not clashing with markdown syntax.
+
 ### Further reading section
 
 At the end of your resource you can add a 'Further reading' section with relevant links to help people understand this topic or our rationale better.


### PR DESCRIPTION
In updating the job description template I feel I've found out the best way to embed templates in our work and make them easily copyable and syntax highlightable.