### PR TITLE
Add process for forward look meetings in a stewarded codebase

### DIFF
--- a/activities/codebase-stewardship/lifecycle.md
+++ b/activities/codebase-stewardship/lifecycle.md
@@ -23,6 +23,15 @@ At the end of assessment, the community:
 Codebases that are in incubation do not yet have the maturity of code and community that we require in the [Standard for Public Code](https://standard.publiccode.net/) and that might be required in the codebase governance.
 
 During incubation, the community works to make the codebase fully Standard compliant (supported by the Foundation for Public Code).
+At least once each year the codebase stewards organizes a meeting with the codebase community to do a forward look.
+The meeting should cover what the ambitions of the community related to meeting more requirements in the Standard for Public Code will be the next year.
+At the latest, a forward look like this should happen about three months before the [general assembly](../../organization/governance-model.md#general-assembly).
+It should be clearly communicated that the information collected in the forward look will feed into a report for the general assembly.
+The forward look could either be part of a regular product steering meeting if such exist, or be a separate meeting.
+Afterwards, the codebase stewards prepares a “state of the codebases”, covering all codebases in stewardship, to the general assembly so that the members can make informed decisions during it.
+Of particular interest for the codebase stewards is if the general assembly wants to prioritize a codebase for strategic reasons, even if compliance with the Standard for Public Code is unlikely the coming year.
+Such decision will give the codebase stewards the mandate to continue stewarding the incubated codebase.
+Alternatively, the members can decide that stop the incubation of a codebase that doesn’t present any renewed ambitions and simply end the lifecycle.
 
 Repositories of codebases in incubation will have clear indicators that the codebase and community are not yet mature, displayed in prominent places.
 


### PR DESCRIPTION
Based on the process documented in [the Foundation for Public Code community call](https://blog.publiccode.net/community%20call/2021/11/24/notes-from-community-call-18-november-2021.html).

Fixes #1023 
It also makes progress on #951.
Part of the [codebase stewards'  Q4 goals](https://blog.publiccode.net/news/2021/11/03/stewards-end-of-year-goals.html). 

-----
[View rendered activities/codebase-stewardship/lifecycle.md](https://github.com/publiccodenet/about/blob/forward-look-process/activities/codebase-stewardship/lifecycle.md)