### PR TITLE
Add user personas templates and index the folder in codebase stewardship

### DIFF
--- a/activities/codebase-stewardship/index.md
+++ b/activities/codebase-stewardship/index.md
@@ -29,7 +29,7 @@ We can provide codebase stewardship from the beginning of the development or for
 * [community assets](community-assets.md)
 * [product assets needed during early incubation](product-assets-for-early-incubation.md)
 * [guide for using Odoo to track our codebases](odoo-codebases.md)
-* [user personas templates](/user-personas.md)
+* [user personas templates](/user-personas/index.md)
 
 ### Templates
 

--- a/activities/codebase-stewardship/index.md
+++ b/activities/codebase-stewardship/index.md
@@ -29,6 +29,7 @@ We can provide codebase stewardship from the beginning of the development or for
 * [community assets](community-assets.md)
 * [product assets needed during early incubation](product-assets-for-early-incubation.md)
 * [guide for using Odoo to track our codebases](odoo-codebases.md)
+* [user personas templates](user-personas.md)
 
 ### Templates
 

--- a/activities/codebase-stewardship/index.md
+++ b/activities/codebase-stewardship/index.md
@@ -29,7 +29,7 @@ We can provide codebase stewardship from the beginning of the development or for
 * [community assets](community-assets.md)
 * [product assets needed during early incubation](product-assets-for-early-incubation.md)
 * [guide for using Odoo to track our codebases](odoo-codebases.md)
-* [user personas templates](user-personas.md)
+* [user personas templates](/user-personas.md)
 
 ### Templates
 

--- a/activities/codebase-stewardship/user-personas/communications-manager.md
+++ b/activities/codebase-stewardship/user-personas/communications-manager.md
@@ -1,0 +1,59 @@
+---
+type: Resource
+---
+
+# Communication manager at an association of public entities. Civil servant
+
+## Anna
+
+| General                                  | Role | Family |  Salary   |
+| ------------------------------------- | ---------------------------------- | -------- | --- |
+| 36, Barcelona | Communications Manager at an association of public entities                               | Lives with her partner     |   €50K  |
+
+![](https://i.imgur.com/hdirkcm.jpg)
+
+* **Personality**:
+    * Perfectionist.
+    * Social person. Enjoys being the touchpoint in between different stakeholders: municipalities, tenders, etc.
+    * Good at campaigns creation.
+    * Empathy.
+    * Procurement background.
+
+* **Bio**:
+Anna has recently joined the association and thinks it is a good career opportunity. Before that, she was involved with several public organizations, from municipalities to Ministries at least for 9 years.
+
+She follows other top-notch municipalities, provinces and countries around the world to see how their communications are done and likes to gather with colleagues from all over the world. In her free time she enjoys swimming and traveling.
+
+* **Motivations**:
+    * Create a vast network of stakeholders (80%).
+    * Establish as a reliable professional in the public sphere (80%).
+    * Reduce the quality gap in between private and public organizations (60%).
+    * Hands-on her own city/country projects (60%).
+
+* **Goals**:
+    * Unify the style of the Communications.
+    * Get more UX collaboration.
+    * Develop her first big gathering of stakeholders.
+
+* **Frustrations**:
+    * Bureaucracy and procurement can be exhausting sometimes.
+    * COVID-19 has changed the way physical events are done.
+    * Sometimes other managers don't keep her in mind for developing projects.
+
+* **Behavior**:
+    * Creativity (80%).
+    * Events (80%).
+    * Campaigns strategy (70%).
+    * English speaking (30%).
+
+* **Influences**:
+    * Ministries and big municipalities (Public Relations).
+    * Organization culture.
+    * Palo-Alto startups.
+    * Psychology.
+
+* **Apps**:
+    * Mailchimp.
+    * Google Analytics.
+    * Hootsuite.
+    * GitHub.

--- a/activities/codebase-stewardship/user-personas/communications-manager.md
+++ b/activities/codebase-stewardship/user-personas/communications-manager.md
@@ -13,47 +13,55 @@ type: Resource
 ![](https://i.imgur.com/hdirkcm.jpg)
 
 ### Personality
-    * Perfectionist.
-    * Social person. Enjoys being the touchpoint in between different stakeholders: municipalities, tenders, etc.
-    * Good at campaigns creation.
-    * Empathy.
-    * Procurement background.
+
+* Perfectionist.
+* Social person. Enjoys being the touchpoint in between different stakeholders: municipalities, tenders, etc.
+* Good at campaigns creation.
+* Empathy.
+* Procurement background.
 
 ### Bio
+
 Anna has recently joined the association and thinks it is a good career opportunity. Before that, she was involved with several public organizations, from municipalities to Ministries at least for 9 years.
 
 She follows other top-notch municipalities, provinces and countries around the world to see how their communications are done and likes to gather with colleagues from all over the world. In her free time she enjoys swimming and traveling.
 
 ### Motivations
-    * Create a vast network of stakeholders (80%).
-    * Establish as a reliable professional in the public sphere (80%).
-    * Reduce the quality gap in between private and public organizations (60%).
-    * Hands-on her own city/country projects (60%).
+
+* Create a vast network of stakeholders (80%).
+* Establish as a reliable professional in the public sphere (80%).
+* Reduce the quality gap in between private and public organizations (60%).
+* Hands-on her own city/country projects (60%).
 
 ### Goals
-    * Unify the style of the Communications.
-    * Get more UX collaboration.
-    * Develop her first big gathering of stakeholders.
+
+* Unify the style of the Communications.
+* Get more UX collaboration.
+* Develop her first big gathering of stakeholders.
 
 ### Frustrations
-    * Bureaucracy and procurement can be exhausting sometimes.
-    * COVID-19 has changed the way physical events are done.
-    * Sometimes other managers don't keep her in mind for developing projects.
+
+* Bureaucracy and procurement can be exhausting sometimes.
+* COVID-19 has changed the way physical events are done.
+* Sometimes other managers don't keep her in mind for developing projects.
 
 ### Behavior
-    * Creativity (80%).
-    * Events (80%).
-    * Campaigns strategy (70%).
-    * English speaking (30%).
+
+* Creativity (80%).
+* Events (80%).
+* Campaigns strategy (70%).
+* English speaking (30%).
 
 ### Influences
-    * Ministries and big municipalities (Public Relations).
-    * Organization culture.
-    * Palo-Alto startups.
-    * Psychology.
+
+* Ministries and big municipalities (Public Relations).
+* Organization culture.
+* Palo-Alto startups.
+* Psychology.
 
 ### Apps
-    * Mailchimp.
-    * Google Analytics.
-    * Hootsuite.
-    * GitHub.
+
+* Mailchimp.
+* Google Analytics.
+* Hootsuite.
+* GitHub.

--- a/activities/codebase-stewardship/user-personas/communications-manager.md
+++ b/activities/codebase-stewardship/user-personas/communications-manager.md
@@ -10,7 +10,7 @@ type: Resource
 | ------------------------------------- | ---------------------------------- | -------- | --- |
 | 36, Barcelona | Communications Manager at an association of public entities                               | Lives with her partner     |   €50K  |
 
-![](https://i.imgur.com/hdirkcm.jpg)
+![Picture of Anna](https://i.imgur.com/hdirkcm.jpg)
 
 ### Personality
 

--- a/activities/codebase-stewardship/user-personas/communications-manager.md
+++ b/activities/codebase-stewardship/user-personas/communications-manager.md
@@ -12,47 +12,47 @@ type: Resource
 
 ![](https://i.imgur.com/hdirkcm.jpg)
 
-* **Personality**:
+### Personality
     * Perfectionist.
     * Social person. Enjoys being the touchpoint in between different stakeholders: municipalities, tenders, etc.
     * Good at campaigns creation.
     * Empathy.
     * Procurement background.
 
-* **Bio**:
+### Bio
 Anna has recently joined the association and thinks it is a good career opportunity. Before that, she was involved with several public organizations, from municipalities to Ministries at least for 9 years.
 
 She follows other top-notch municipalities, provinces and countries around the world to see how their communications are done and likes to gather with colleagues from all over the world. In her free time she enjoys swimming and traveling.
 
-* **Motivations**:
+### Motivations
     * Create a vast network of stakeholders (80%).
     * Establish as a reliable professional in the public sphere (80%).
     * Reduce the quality gap in between private and public organizations (60%).
     * Hands-on her own city/country projects (60%).
 
-* **Goals**:
+### Goals
     * Unify the style of the Communications.
     * Get more UX collaboration.
     * Develop her first big gathering of stakeholders.
 
-* **Frustrations**:
+### Frustrations
     * Bureaucracy and procurement can be exhausting sometimes.
     * COVID-19 has changed the way physical events are done.
     * Sometimes other managers don't keep her in mind for developing projects.
 
-* **Behavior**:
+### Behavior
     * Creativity (80%).
     * Events (80%).
     * Campaigns strategy (70%).
     * English speaking (30%).
 
-* **Influences**:
+### Influences
     * Ministries and big municipalities (Public Relations).
     * Organization culture.
     * Palo-Alto startups.
     * Psychology.
 
-* **Apps**:
+### Apps
     * Mailchimp.
     * Google Analytics.
     * Hootsuite.

--- a/activities/codebase-stewardship/user-personas/index.md
+++ b/activities/codebase-stewardship/user-personas/index.md
@@ -1,0 +1,19 @@
+---
+type: Index
+---
+
+# User personas
+
+In order to understand better the behavior and aspirations of our community, we've developed this *personas* template folder. In user-centered design and marketing, a persona or user persona is a fictional character created to represent a user type. Our community members have important needs and frustrations that must be kept in mind when developing a resource for them.
+
+Once again, every persona represented here describes the behavior of a hypothesized contributor of our community.
+
+The aim of this set of templates is to be used by public code professionals.
+
+User personas templates:
+
+* [Project manager at a municipality. Civil servant](/project-manager-municipality.md)
+* [Project manager at an association of public entities. Civil servant](/project-manager-association.md)
+* [Communication manager at an association of public entities. Civil servant](/communications-manager.md)
+* [Policy maker. Civil servant](/policy-maker-officer.md)
+* [Vendor. Owner of a small software development company](/vendor-owner-developer.md)

--- a/activities/codebase-stewardship/user-personas/index.md
+++ b/activities/codebase-stewardship/user-personas/index.md
@@ -12,8 +12,8 @@ The aim of this set of templates is to be used by public code professionals.
 
 User personas templates:
 
-* [Project manager at a municipality. Civil servant](/project-manager-municipality.md)
-* [Project manager at an association of public entities. Civil servant](/project-manager-association.md)
-* [Communication manager at an association of public entities. Civil servant](/communications-manager.md)
-* [Policy maker. Civil servant](/policy-maker-officer.md)
-* [Vendor. Owner of a small software development company](/vendor-owner-developer.md)
+* [Project manager at a municipality. Civil servant](project-manager-municipality.md)
+* [Project manager at an association of public entities. Civil servant](project-manager-association.md)
+* [Communication manager at an association of public entities. Civil servant](communications-manager.md)
+* [Policy maker. Civil servant](policy-maker-officer.md)
+* [Vendor. Owner of a small software development company](vendor-owner-developer.md)

--- a/activities/codebase-stewardship/user-personas/policy-maker-officer.md
+++ b/activities/codebase-stewardship/user-personas/policy-maker-officer.md
@@ -13,47 +13,55 @@ type: Resource
 ![](https://images.unsplash.com/photo-1605462863863-10d9e47e15ee?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=3870&q=80)
 
 ### Personality
-    * Creative.
-    * Social and talkative.
-    * Strong sense of social justice.
-    * Honest with the citizen.
-    * Committed.
-    * Abstract way of thinking.
+
+* Creative.
+* Social and talkative.
+* Strong sense of social justice.
+* Honest with the citizen.
+* Committed.
+* Abstract way of thinking.
 
 ### Bio
+
 Born and raised in Italy although he has travelled a lot. He is a curious mind and a gift when talking to people from different backgrounds. After a couple of bad experiences in the working world he decided to try as civil servant to work for his country. He's been a civil servant for six years now.
 
 During the weekends he likes to read, hang out with his friends and engage in some social action in his city.
 
 ### Motivations
-    * Create public infrastructure in the public code field (80%).
-    * Build bridges in between citizenship and public organizations (80%).
-    * Get things done (60%).
-    * Connector: politicians and project managers (80%).
+
+* Create public infrastructure in the public code field (80%).
+* Build bridges in between citizenship and public organizations (80%).
+* Get things done (60%).
+* Connector: politicians and project managers (80%).
 
 ### Goals
-    * Make project managers and vendors understand what is expected of them.
-    * Make politicians understand issues from the real world and problems the project managers have.
-    * Build a community that gathers all.
+
+* Make project managers and vendors understand what is expected of them.
+* Make politicians understand issues from the real world and problems the project managers have.
+* Build a community that gathers all.
 
 ### Frustrations
-    * Corruption in the public bodies.
-    * People that got lazy with their permanent contract and lost all their will to change society.
-    * Slow decision making process, rigid and archaic way to reach out to politicians.
+
+* Corruption in the public bodies.
+* People that got lazy with their permanent contract and lost all their will to change society.
+* Slow decision making process, rigid and archaic way to reach out to politicians.
 
 ### Behavior
-    * Python & Open Source (80%).
-    * Politicians forms (90%).
-    * Meetings (40%).
-    * Legal texts (80%).
+
+* Python & Open Source (80%).
+* Politicians forms (90%).
+* Meetings (40%).
+* Legal texts (80%).
 
 ### Influences
-    * French revolution.
-    * Mark Fisher.
-    * Economists from 19th century.
-    * Public Code.
+
+* French revolution.
+* Mark Fisher.
+* Economists from 19th century.
+* Public Code.
 
 ### Apps
-    * Protonmail.
-    * GitLab.
-    * Tendernet.
+
+* Protonmail.
+* GitLab.
+* Tendernet.

--- a/activities/codebase-stewardship/user-personas/policy-maker-officer.md
+++ b/activities/codebase-stewardship/user-personas/policy-maker-officer.md
@@ -10,7 +10,7 @@ type: Resource
 | ------------------------------------- | ---------------------------------- | -------- | --- |
 | 34, Rome | Policy & Engagement Officer                                | Single    |   45k  |
 
-![](https://images.unsplash.com/photo-1605462863863-10d9e47e15ee?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=3870&q=80)
+![Picture of Mario](https://images.unsplash.com/photo-1605462863863-10d9e47e15ee?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=3870&q=80)
 
 ### Personality
 

--- a/activities/codebase-stewardship/user-personas/policy-maker-officer.md
+++ b/activities/codebase-stewardship/user-personas/policy-maker-officer.md
@@ -1,0 +1,59 @@
+---
+type: Resource
+---
+
+# Policy maker. Civil servant
+
+## Mario
+
+| General                                  | Role | Family |  Salary   |
+| ------------------------------------- | ---------------------------------- | -------- | --- |
+| 34, Rome | Policy & Engagement Officer                                | Single    |   45k  |
+
+![](https://images.unsplash.com/photo-1605462863863-10d9e47e15ee?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=3870&q=80)
+
+* **Personality**:
+    * Creative.
+    * Social and talkative.
+    * Strong sense of social justice.
+    * Honest with the citizen.
+    * Committed.
+    * Abstract way of thinking.
+
+* **Bio**:
+Born and raised in Italy although he has travelled a lot. He is a curious mind and a gift when talking to people from different backgrounds. After a couple of bad experiences in the working world he decided to try as civil servant to work for his country. He's been a civil servant for six years now.
+
+During the weekends he likes to read, hang out with his friends and engage in some social action in his city.
+
+* **Motivations**:
+    * Create public infrastructure in the public code field (80%).
+    * Build bridges in between citizenship and public organizations (80%).
+    * Get things done (60%).
+    * Connector: politicians and project managers (80%).
+
+* **Goals**:
+    * Make project managers and vendors understand what is expected of them.
+    * Make politicians understand issues from the real world and problems the project managers have.
+    * Build a community that gathers all.
+
+* **Frustrations**:
+    * Corruption in the public bodies.
+    * People that got lazy with their permanent contract and lost all their will to change society.
+    * Slow decision making process, rigid and archaic way to reach out to politicians.
+
+* **Behavior**:
+    * Python & Open Source (80%).
+    * Politicians forms (90%).
+    * Meetings (40%).
+    * Legal texts (80%).
+
+* **Influences**:
+    * French revolution.
+    * Mark Fisher.
+    * Economists from 19th century.
+    * Public Code.
+
+* **Apps**:
+    * Protonmail.
+    * GitLab.
+    * Tendernet.

--- a/activities/codebase-stewardship/user-personas/policy-maker-officer.md
+++ b/activities/codebase-stewardship/user-personas/policy-maker-officer.md
@@ -12,7 +12,7 @@ type: Resource
 
 ![](https://images.unsplash.com/photo-1605462863863-10d9e47e15ee?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=3870&q=80)
 
-* **Personality**:
+### Personality
     * Creative.
     * Social and talkative.
     * Strong sense of social justice.
@@ -20,40 +20,40 @@ type: Resource
     * Committed.
     * Abstract way of thinking.
 
-* **Bio**:
+### Bio
 Born and raised in Italy although he has travelled a lot. He is a curious mind and a gift when talking to people from different backgrounds. After a couple of bad experiences in the working world he decided to try as civil servant to work for his country. He's been a civil servant for six years now.
 
 During the weekends he likes to read, hang out with his friends and engage in some social action in his city.
 
-* **Motivations**:
+### Motivations
     * Create public infrastructure in the public code field (80%).
     * Build bridges in between citizenship and public organizations (80%).
     * Get things done (60%).
     * Connector: politicians and project managers (80%).
 
-* **Goals**:
+### Goals
     * Make project managers and vendors understand what is expected of them.
     * Make politicians understand issues from the real world and problems the project managers have.
     * Build a community that gathers all.
 
-* **Frustrations**:
+### Frustrations
     * Corruption in the public bodies.
     * People that got lazy with their permanent contract and lost all their will to change society.
     * Slow decision making process, rigid and archaic way to reach out to politicians.
 
-* **Behavior**:
+### Behavior
     * Python & Open Source (80%).
     * Politicians forms (90%).
     * Meetings (40%).
     * Legal texts (80%).
 
-* **Influences**:
+### Influences
     * French revolution.
     * Mark Fisher.
     * Economists from 19th century.
     * Public Code.
 
-* **Apps**:
+### Apps
     * Protonmail.
     * GitLab.
     * Tendernet.

--- a/activities/codebase-stewardship/user-personas/project-manager-association.md
+++ b/activities/codebase-stewardship/user-personas/project-manager-association.md
@@ -12,49 +12,49 @@ type: Resource
 
 ![](https://i.imgur.com/gXi8mJP.jpg)
 
-* **Personality**:
+### Personality
     * Empathy.
     * Organization.
     * Team worker.
     * Responsible.
 
-* **Bio**:
+### Bio
 Lisa joined the association of municipalities five years ago. In her previous job at a private company she nurtured a vast network of those who are her clients (municipalities) nowadays.
 
 She is a business management professional with a stable life. She enjoys spending time with her family and biking with her husband on Saturdays.
 
-* **Motivations**:
+### Motivations
     * Efficiency (90%).
     * Contribute to the common good (40%).
     * Organizational change/innovation (70%).
     * High skilled team (80%).
     * Promotion (80%).
 
-* **Goals**:
+### Goals
     * Create a good environment in her team.
     * Deliver projects on time with the best quality.
     * Hire a realiable vendor.
     * Advance with small steps but qualitative ones.
 
-* **Frustrations**:
+### Frustrations
     * A lot of politics involved.
     * New tools to learn.
     * A lot of uncertainty and risks associated with Public Code.
 
-* **Behavior**:
+### Behavior
     * Retrospectives (90%).
     * Trainings for her team (60%).
     * Freedom to her team (60%).
     * Open Source (40%).
     * Documentation (40%).
 
-* **Influences**:
+### Influences
     * MBA.
     * Newsletter of German civil servants.
     * Peers in other countries.
     * Lean.
 
-* **Apps**:
+### Apps
     * Intranet of her organization.
     * Microsoft Teams.
     * DB Navigator (public transport in Germany).

--- a/activities/codebase-stewardship/user-personas/project-manager-association.md
+++ b/activities/codebase-stewardship/user-personas/project-manager-association.md
@@ -1,0 +1,60 @@
+---
+type: Resource
+---
+
+# Project manager at an association of public entities. Civil servant
+
+## Lisa
+
+| General                                  | Role | Family |  Salary   |
+| ------------------------------------- | ---------------------------------- | -------- | --- |
+| 41, Essen (Germany) | Project Manager at an association of municipalities                               |  Married + 2 teen kids  |   €70K |
+
+![](https://i.imgur.com/gXi8mJP.jpg)
+
+* **Personality**:
+    * Empathy.
+    * Organization.
+    * Team worker.
+    * Responsible.
+
+* **Bio**:
+Lisa joined the association of municipalities five years ago. In her previous job at a private company she nurtured a vast network of those who are her clients (municipalities) nowadays.
+
+She is a business management professional with a stable life. She enjoys spending time with her family and biking with her husband on Saturdays.
+
+* **Motivations**:
+    * Efficiency (90%).
+    * Contribute to the common good (40%).
+    * Organizational change/innovation (70%).
+    * High skilled team (80%).
+    * Promotion (80%).
+
+* **Goals**:
+    * Create a good environment in her team.
+    * Deliver projects on time with the best quality.
+    * Hire a realiable vendor.
+    * Advance with small steps but qualitative ones.
+
+* **Frustrations**:
+    * A lot of politics involved.
+    * New tools to learn.
+    * A lot of uncertainty and risks associated with Public Code.
+
+* **Behavior**:
+    * Retrospectives (90%).
+    * Trainings for her team (60%).
+    * Freedom to her team (60%).
+    * Open Source (40%).
+    * Documentation (40%).
+
+* **Influences**:
+    * MBA.
+    * Newsletter of German civil servants.
+    * Peers in other countries.
+    * Lean.
+
+* **Apps**:
+    * Intranet of her organization.
+    * Microsoft Teams.
+    * DB Navigator (public transport in Germany).

--- a/activities/codebase-stewardship/user-personas/project-manager-association.md
+++ b/activities/codebase-stewardship/user-personas/project-manager-association.md
@@ -10,7 +10,7 @@ type: Resource
 | ------------------------------------- | ---------------------------------- | -------- | --- |
 | 41, Essen (Germany) | Project Manager at an association of municipalities                               |  Married + 2 teen kids  |   €70K |
 
-![](https://i.imgur.com/gXi8mJP.jpg)
+![Picture of Lisa](https://i.imgur.com/gXi8mJP.jpg)
 
 ### Personality
 

--- a/activities/codebase-stewardship/user-personas/project-manager-association.md
+++ b/activities/codebase-stewardship/user-personas/project-manager-association.md
@@ -13,48 +13,56 @@ type: Resource
 ![](https://i.imgur.com/gXi8mJP.jpg)
 
 ### Personality
-    * Empathy.
-    * Organization.
-    * Team worker.
-    * Responsible.
+
+* Empathy.
+* Organization.
+* Team worker.
+* Responsible.
 
 ### Bio
+
 Lisa joined the association of municipalities five years ago. In her previous job at a private company she nurtured a vast network of those who are her clients (municipalities) nowadays.
 
 She is a business management professional with a stable life. She enjoys spending time with her family and biking with her husband on Saturdays.
 
 ### Motivations
-    * Efficiency (90%).
-    * Contribute to the common good (40%).
-    * Organizational change/innovation (70%).
-    * High skilled team (80%).
-    * Promotion (80%).
+
+* Efficiency (90%).
+* Contribute to the common good (40%).
+* Organizational change/innovation (70%).
+* High skilled team (80%).
+* Promotion (80%).
 
 ### Goals
-    * Create a good environment in her team.
-    * Deliver projects on time with the best quality.
-    * Hire a realiable vendor.
-    * Advance with small steps but qualitative ones.
+
+* Create a good environment in her team.
+* Deliver projects on time with the best quality.
+* Hire a realiable vendor.
+* Advance with small steps but qualitative ones.
 
 ### Frustrations
-    * A lot of politics involved.
-    * New tools to learn.
-    * A lot of uncertainty and risks associated with Public Code.
+
+* A lot of politics involved.
+* New tools to learn.
+* A lot of uncertainty and risks associated with Public Code.
 
 ### Behavior
-    * Retrospectives (90%).
-    * Trainings for her team (60%).
-    * Freedom to her team (60%).
-    * Open Source (40%).
-    * Documentation (40%).
+
+* Retrospectives (90%).
+* Trainings for her team (60%).
+* Freedom to her team (60%).
+* Open Source (40%).
+* Documentation (40%).
 
 ### Influences
-    * MBA.
-    * Newsletter of German civil servants.
-    * Peers in other countries.
-    * Lean.
+
+* MBA.
+* Newsletter of German civil servants.
+* Peers in other countries.
+* Lean.
 
 ### Apps
-    * Intranet of her organization.
-    * Microsoft Teams.
-    * DB Navigator (public transport in Germany).
+
+* Intranet of her organization.
+* Microsoft Teams.
+* DB Navigator (public transport in Germany).

--- a/activities/codebase-stewardship/user-personas/project-manager-municipality.md
+++ b/activities/codebase-stewardship/user-personas/project-manager-municipality.md
@@ -10,7 +10,7 @@ type: Resource
 | ------------------------------------- | ---------------------------------- | -------- | --- |
 | 44, Delft | Project Manager at Municipality of Rotterdam                               | Married + 2 young kids     |   €80K  |
 
-![](https://i.imgur.com/TPpxjGK.jpg)
+![Picture of Bas](https://i.imgur.com/TPpxjGK.jpg)
 
 ### Personality
 

--- a/activities/codebase-stewardship/user-personas/project-manager-municipality.md
+++ b/activities/codebase-stewardship/user-personas/project-manager-municipality.md
@@ -1,0 +1,59 @@
+---
+type: Resource
+---
+
+# Project manager at a municipality. Civil servant
+
+## Bas
+
+| General                                  | Role | Family |  Salary   |
+| ------------------------------------- | ---------------------------------- | -------- | --- |
+| 44, Delft | Project Manager at Municipality of Rotterdam                               | Married + 2 young kids     |   €80K  |
+
+![](https://i.imgur.com/TPpxjGK.jpg)
+
+* **Personality**:
+    * Analytical decisions.
+    * Public speaking.
+    * Organization.
+    * Networking.
+    * Resolutive, Get Things Done.
+
+* **Bio**:
+Bas has been working for the Municipality of Rotterdam for 3 years. Before joining the public sphere, he worked as a Project Manager for a decade in private companies.
+
+He is an engineer that enjoys spending time with his family. In his free time he meets his long-time friends and their families and play football while BBQing. During winter time, he enjoys organizing skiing trips with them.
+
+* **Motivations**:
+    * Contribute to the common good (40%).
+    * Organizational change/innovation (80%).
+    * High skilled team (80%).
+    * Promotion (60%).
+
+* **Goals**:
+    * Make his projects known and replicated by other municipalities (portfolio project for him).
+    * Bigger team.
+    * Become a digital transformation paradigm.
+
+* **Frustrations**:
+    * Not enough budget.
+    * Bureaucracy and procurement can be exhausting sometimes.
+    * It's difficult to set a pipeline. Too many stakeholders involved.
+    * A lot of politics in his daily job.
+
+* **Behavior**:
+    * 1:1 (80%).
+    * Meetings (60%).
+    * Sprint planing (80%).
+    * Documentation (40%).
+
+* **Influences**:
+    * Lean & Agile.
+    * Podcasts.
+    * Colleagues.
+    * Gov.uk (DGS).
+
+* **Apps**:
+    * Gmail.
+    * Microsoft Teams.
+    * [Flitsmeister](https://www.flitsmeister.nl/).

--- a/activities/codebase-stewardship/user-personas/project-manager-municipality.md
+++ b/activities/codebase-stewardship/user-personas/project-manager-municipality.md
@@ -13,47 +13,55 @@ type: Resource
 ![](https://i.imgur.com/TPpxjGK.jpg)
 
 ### Personality
-    * Analytical decisions.
-    * Public speaking.
-    * Organization.
-    * Networking.
-    * Resolutive, Get Things Done.
+
+* Analytical decisions.
+* Public speaking.
+* Organization.
+* Networking.
+* Resolutive, Get Things Done.
 
 ### Bio
+
 Bas has been working for the Municipality of Rotterdam for 3 years. Before joining the public sphere, he worked as a Project Manager for a decade in private companies.
 
 He is an engineer that enjoys spending time with his family. In his free time he meets his long-time friends and their families and play football while BBQing. During winter time, he enjoys organizing skiing trips with them.
 
 ### Motivations
-    * Contribute to the common good (40%).
-    * Organizational change/innovation (80%).
-    * High skilled team (80%).
-    * Promotion (60%).
+
+* Contribute to the common good (40%).
+* Organizational change/innovation (80%).
+* High skilled team (80%).
+* Promotion (60%).
 
 ### Goals
-    * Make his projects known and replicated by other municipalities (portfolio project for him).
-    * Bigger team.
-    * Become a digital transformation paradigm.
+
+* Make his projects known and replicated by other municipalities (portfolio project for him).
+* Bigger team.
+* Become a digital transformation paradigm.
 
 ### Frustrations
-    * Not enough budget.
-    * Bureaucracy and procurement can be exhausting sometimes.
-    * It's difficult to set a pipeline. Too many stakeholders involved.
-    * A lot of politics in his daily job.
+
+* Not enough budget.
+* Bureaucracy and procurement can be exhausting sometimes.
+* It's difficult to set a pipeline. Too many stakeholders involved.
+* A lot of politics in his daily job.
 
 ### Behavior
-    * 1:1 (80%).
-    * Meetings (60%).
-    * Sprint planing (80%).
-    * Documentation (40%).
+
+* 1:1 (80%).
+* Meetings (60%).
+* Sprint planing (80%).
+* Documentation (40%).
 
 ### Influences
-    * Lean & Agile.
-    * Podcasts.
-    * Colleagues.
-    * Gov.uk (DGS).
+
+* Lean & Agile.
+* Podcasts.
+* Colleagues.
+* Gov.uk (DGS).
 
 ### Apps
-    * Gmail.
-    * Microsoft Teams.
-    * [Flitsmeister](https://www.flitsmeister.nl/).
+
+* Gmail.
+* Microsoft Teams.
+* [Flitsmeister](https://www.flitsmeister.nl/).

--- a/activities/codebase-stewardship/user-personas/project-manager-municipality.md
+++ b/activities/codebase-stewardship/user-personas/project-manager-municipality.md
@@ -12,48 +12,48 @@ type: Resource
 
 ![](https://i.imgur.com/TPpxjGK.jpg)
 
-* **Personality**:
+### Personality
     * Analytical decisions.
     * Public speaking.
     * Organization.
     * Networking.
     * Resolutive, Get Things Done.
 
-* **Bio**:
+### Bio
 Bas has been working for the Municipality of Rotterdam for 3 years. Before joining the public sphere, he worked as a Project Manager for a decade in private companies.
 
 He is an engineer that enjoys spending time with his family. In his free time he meets his long-time friends and their families and play football while BBQing. During winter time, he enjoys organizing skiing trips with them.
 
-* **Motivations**:
+### Motivations
     * Contribute to the common good (40%).
     * Organizational change/innovation (80%).
     * High skilled team (80%).
     * Promotion (60%).
 
-* **Goals**:
+### Goals
     * Make his projects known and replicated by other municipalities (portfolio project for him).
     * Bigger team.
     * Become a digital transformation paradigm.
 
-* **Frustrations**:
+### Frustrations
     * Not enough budget.
     * Bureaucracy and procurement can be exhausting sometimes.
     * It's difficult to set a pipeline. Too many stakeholders involved.
     * A lot of politics in his daily job.
 
-* **Behavior**:
+### Behavior
     * 1:1 (80%).
     * Meetings (60%).
     * Sprint planing (80%).
     * Documentation (40%).
 
-* **Influences**:
+### Influences
     * Lean & Agile.
     * Podcasts.
     * Colleagues.
     * Gov.uk (DGS).
 
-* **Apps**:
+### Apps
     * Gmail.
     * Microsoft Teams.
     * [Flitsmeister](https://www.flitsmeister.nl/).

--- a/activities/codebase-stewardship/user-personas/vendor-owner-developer.md
+++ b/activities/codebase-stewardship/user-personas/vendor-owner-developer.md
@@ -12,48 +12,48 @@ type: Resource
 
 ![](https://i.imgur.com/9yY4LTZ.jpg)
 
-* **Personality**:
+### Personality
    * Perfectionist.
    * Software crafter & eXtreme Programming.
    * Agile management.
    * Hard worker.
    * Versatile tech & manager.
 
-* **Bio**:
+### Bio
 Founded his own software company a decade ago, focused on supporting public administrations. Before that, he worked in several public entities. Not much experience working for other private companies.
 
 He founded the company with his best friend, who has been there for him since kids. Quiet life with his wife.
 
-* **Motivations**:
+### Motivations
    * Improving quality in the public sphere (80%).
    * Create a solid portfolio within public organisms (80%).
    * Teamwork (60%).
    * Certain flexibility to work in his own preferred times (late at night) (80%).
 
-* **Goals**:
+### Goals
    * Become a successful business use case in public organisms.
    * Get more budget and a contract extension with the public projects they've been working with.
    * Get on with different actors involved in projects.
 
-* **Frustrations**:
+### Frustrations
    * Unable to fully make his own decisions. Contracting parties don't trust him 100%.
    * New tender to share the project with.
    * Lack of budget.
    * Big investment, big risk (one single client, specific working conditions).
 
-* **Behavior**:
+### Behavior
    * Python & Open Source (80%).
    * Sprint planning (80%).
    * Testing (70%).
    * GitHub (90%).
 
-* **Influences**:
+### Influences
    * Uncle Bob & Martin Fowler.
    * Linus Torvalds.
    * Other small tenders with a lot of trajectory in the public sphere.
    * Public Code.
 
-* **Apps**:
+### Apps
    * Basecamp.
    * GitHub.
    * Tendernet.

--- a/activities/codebase-stewardship/user-personas/vendor-owner-developer.md
+++ b/activities/codebase-stewardship/user-personas/vendor-owner-developer.md
@@ -13,47 +13,55 @@ type: Resource
 ![](https://i.imgur.com/9yY4LTZ.jpg)
 
 ### Personality
-   * Perfectionist.
-   * Software crafter & eXtreme Programming.
-   * Agile management.
-   * Hard worker.
-   * Versatile tech & manager.
+
+* Perfectionist.
+* Software crafter & eXtreme Programming.
+* Agile management.
+* Hard worker.
+* Versatile tech & manager.
 
 ### Bio
+
 Founded his own software company a decade ago, focused on supporting public administrations. Before that, he worked in several public entities. Not much experience working for other private companies.
 
 He founded the company with his best friend, who has been there for him since kids. Quiet life with his wife.
 
 ### Motivations
-   * Improving quality in the public sphere (80%).
-   * Create a solid portfolio within public organisms (80%).
-   * Teamwork (60%).
-   * Certain flexibility to work in his own preferred times (late at night) (80%).
+
+* Improving quality in the public sphere (80%).
+* Create a solid portfolio within public organisms (80%).
+* Teamwork (60%).
+* Certain flexibility to work in his own preferred times (late at night) (80%).
 
 ### Goals
-   * Become a successful business use case in public organisms.
-   * Get more budget and a contract extension with the public projects they've been working with.
-   * Get on with different actors involved in projects.
+
+* Become a successful business use case in public organisms.
+* Get more budget and a contract extension with the public projects they've been working with.
+* Get on with different actors involved in projects.
 
 ### Frustrations
-   * Unable to fully make his own decisions. Contracting parties don't trust him 100%.
-   * New tender to share the project with.
-   * Lack of budget.
-   * Big investment, big risk (one single client, specific working conditions).
+
+* Unable to fully make his own decisions. Contracting parties don't trust him 100%.
+* New tender to share the project with.
+* Lack of budget.
+* Big investment, big risk (one single client, specific working conditions).
 
 ### Behavior
-   * Python & Open Source (80%).
-   * Sprint planning (80%).
-   * Testing (70%).
-   * GitHub (90%).
+
+* Python & Open Source (80%).
+* Sprint planning (80%).
+* Testing (70%).
+* GitHub (90%).
 
 ### Influences
-   * Uncle Bob & Martin Fowler.
-   * Linus Torvalds.
-   * Other small tenders with a lot of trajectory in the public sphere.
-   * Public Code.
+
+* Uncle Bob & Martin Fowler.
+* Linus Torvalds.
+* Other small tenders with a lot of trajectory in the public sphere.
+* Public Code.
 
 ### Apps
-   * Basecamp.
-   * GitHub.
-   * Tendernet.
+
+* Basecamp.
+* GitHub.
+* Tendernet.

--- a/activities/codebase-stewardship/user-personas/vendor-owner-developer.md
+++ b/activities/codebase-stewardship/user-personas/vendor-owner-developer.md
@@ -10,7 +10,7 @@ type: Resource
 | ------------------------------------- | ---------------------------------- | -------- | --- |
 | 40, Strasbourg | Owner of a 10 people company that develops software for public organizations                               | Married    |   Depends on projects  |
 
-![](https://i.imgur.com/9yY4LTZ.jpg)
+![Picture of Michel](https://i.imgur.com/9yY4LTZ.jpg)
 
 ### Personality
 

--- a/activities/codebase-stewardship/user-personas/vendor-owner-developer.md
+++ b/activities/codebase-stewardship/user-personas/vendor-owner-developer.md
@@ -1,0 +1,59 @@
+---
+type: Resource
+---
+
+# Vendor. Owner of a small software development company
+
+## Michel
+
+| General                                  | Role | Family |  Salary   |
+| ------------------------------------- | ---------------------------------- | -------- | --- |
+| 40, Strasbourg | Owner of a 10 people company that develops software for public organizations                               | Married    |   Depends on projects  |
+
+![](https://i.imgur.com/9yY4LTZ.jpg)
+
+* **Personality**:
+   * Perfectionist.
+   * Software crafter & eXtreme Programming.
+   * Agile management.
+   * Hard worker.
+   * Versatile tech & manager.
+
+* **Bio**:
+Founded his own software company a decade ago, focused on supporting public administrations. Before that, he worked in several public entities. Not much experience working for other private companies.
+
+He founded the company with his best friend, who has been there for him since kids. Quiet life with his wife.
+
+* **Motivations**:
+   * Improving quality in the public sphere (80%).
+   * Create a solid portfolio within public organisms (80%).
+   * Teamwork (60%).
+   * Certain flexibility to work in his own preferred times (late at night) (80%).
+
+* **Goals**:
+   * Become a successful business use case in public organisms.
+   * Get more budget and a contract extension with the public projects they've been working with.
+   * Get on with different actors involved in projects.
+
+* **Frustrations**:
+   * Unable to fully make his own decisions. Contracting parties don't trust him 100%.
+   * New tender to share the project with.
+   * Lack of budget.
+   * Big investment, big risk (one single client, specific working conditions).
+
+* **Behavior**:
+   * Python & Open Source (80%).
+   * Sprint planning (80%).
+   * Testing (70%).
+   * GitHub (90%).
+
+* **Influences**:
+   * Uncle Bob & Martin Fowler.
+   * Linus Torvalds.
+   * Other small tenders with a lot of trajectory in the public sphere.
+   * Public Code.
+
+* **Apps**:
+   * Basecamp.
+   * GitHub.
+   * Tendernet.


### PR DESCRIPTION
As discussed in last stewards' meeting, uploading of the created user personas templates so our community can benefit from its (re)use.

-----
[View rendered activities/codebase-stewardship/user-personas/communications-manager.md](https://github.com/AlbaRoza/about/blob/user-personas/activities/codebase-stewardship/user-personas/communications-manager.md)
[View rendered activities/codebase-stewardship/user-personas/index.md](https://github.com/AlbaRoza/about/blob/user-personas/activities/codebase-stewardship/user-personas/index.md)
[View rendered activities/codebase-stewardship/user-personas/policy-maker-officer.md](https://github.com/AlbaRoza/about/blob/user-personas/activities/codebase-stewardship/user-personas/policy-maker-officer.md)
[View rendered activities/codebase-stewardship/user-personas/project-manager-association.md](https://github.com/AlbaRoza/about/blob/user-personas/activities/codebase-stewardship/user-personas/project-manager-association.md)
[View rendered activities/codebase-stewardship/user-personas/project-manager-municipality.md](https://github.com/AlbaRoza/about/blob/user-personas/activities/codebase-stewardship/user-personas/project-manager-municipality.md)
[View rendered activities/codebase-stewardship/user-personas/vendor-owner-developer.md](https://github.com/AlbaRoza/about/blob/user-personas/activities/codebase-stewardship/user-personas/vendor-owner-developer.md)