### PR TITLE
Fix forgotten management > administration

### DIFF
--- a/activities/index.md
+++ b/activities/index.md
@@ -19,7 +19,7 @@ Activities that support the above as well as make staff operations work:
 * [Documentation](documentation/index.md)
 * [Events](events/index.md)
 * [Explaining codebase stewardship](explaining-codebase-stewardship/index.md)
-* [Finance management](financial-administration/index.md)
+* [Financial administration](financial-administration/index.md)
 * [Live streaming](live-streaming/index.md)
 * [Maintenance of the Standard for Public Code](standard-maintenance/index.md)
 * [Member relations](member-relations/index.md)


### PR DESCRIPTION
Having the link be in line with the thing

-----
[View rendered activities/index.md](https://github.com/publiccodenet/about/blob/bvhme-patch-1/activities/index.md)