### PR TITLE
Remove explicit dependency on faraday from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,3 @@ gem 'github-pages', group: :jekyll_plugins
 gem 'html-proofer'
 gem 'chef-utils'
 gem 'mdl'
-gem "faraday"


### PR DESCRIPTION
To work around a github issue, "faraday" was added and pinned to 0.17
in commit b82528b76056ec8425d4cd9d7d0b6209dcf104aa.

Later it was unpinned ( 5febab3c9fb46e09563c8beca99c6e52037fd7a0 ) but
probably should have been removed, as the codebase does not directly
depend upon it.

Recently, the explicit inclusion of "faraday" in the Gemfile seems to
invite an issue with resolving dependencies. Below you can see where I
kill it after about 10 minutes:

	eric@dione:~/src/publiccodenet-about$ git status
	On branch develop
	Your branch is up to date with 'upstream/develop'.

	nothing to commit, working tree clean
	eric@dione:~/src/publiccodenet-about$ git show
	commit afc638d1cabf6b7682bfff121b0fe9b287ad4917 (HEAD -> develop,
	upstream/develop, upstream/HEAD)
	Merge: 0b719d7b 1fb3cbeb
	Author: Eric Herman <eric@publiccode.net>
	Date:   Tue Jan 18 09:55:37 2022 +0000

	    Merge pull request #1064 from publiccodenet/change-setup-ruby

	    Change setup-ruby

	eric@dione:~/src/publiccodenet-about$ git clean -dxff
	eric@dione:~/src/publiccodenet-about$ bundle config set path
	vendor/bundle
	eric@dione:~/src/publiccodenet-about$ time bundle install
	Fetching gem metadata from https://rubygems.org/...........
	Fetching gem metadata from https://rubygems.org/.
	Resolving dependencies..............................................^C

	real	9m27,651s
	user	9m25,480s
	sys	0m0,316s
	eric@dione:~/src/publiccodenet-about(1)$

Removing "faraday" from Gemfile allows it to complete in about 30
seconds on my laptop.