### PR TITLE
Fix link to mailing list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Our [contributor guide for individuals](contributor-guides/for-individuals.md) e
 
 We’re especially interested in learning what you need to implement the [Standard for Public Code](https://standard.publiccode.net/) in your organization. Please [raise an issue](https://standard.publiccode.net/CONTRIBUTING.html) or email us at <info@publiccode.net>.
 
-[Sign up for our mailing list](https://docs.google.com/forms/d/e/1FAIpQLSdOArHWz6leVrOdOLcVlm9nbgKSrn5gxAgCIytZsAWgqnkbWQ/viewform) to join our community and keep up with our news.
+[Sign up for our mailing list](https://odoo.publiccode.net/survey/start/594b9243-c7e5-4bc1-8714-35137c971842) to join our community and keep up with our news.
 
 ## Public organizations
 


### PR DESCRIPTION
Odoo instead of old Google form.

-----
[View rendered CONTRIBUTING.md](https://github.com/publiccodenet/about/blob/fix-mailinglist-link/CONTRIBUTING.md)