### PR TITLE
Redirect contributing flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,3 +36,7 @@ If you believe there should be a structural solution to making open source softw
 ## International sanctions
 
 As a legal association in the Netherlands, the Foundation for Public Code follows [EU law regarding international sanctions](https://sanctionsmap.eu/#/main).
+
+## Staff
+
+Find out more how [our staff contribute](contributor-guides/for-staff.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,4 +39,4 @@ As a legal association in the Netherlands, the Foundation for Public Code follow
 
 ## Staff
 
-Find out more how [our staff contribute](contributor-guides/for-staff.md)
+Find out more how [our staff contribute](contributor-guides/for-staff.md).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It's `main` branch is the official ['source of truth'](GOVERNANCE.md) and centra
 
 ## Contributing
 
-We are looking for people like you to [contribute](CONTRIBUTING.md) to this project by suggesting improvements and helping develop the Foundation for Public Code. 😊 Get started by reading our [Contributors Guide](contributor-guides/index.md) and [how we structure our documentation](activities/documentation/index.md).
+We are looking for people like you to [contribute](CONTRIBUTING.md) to this project by suggesting improvements and helping develop the Foundation for Public Code. 😊
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms. Please be lovely to all other community members.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It's `main` branch is the official ['source of truth'](GOVERNANCE.md) and centra
 
 ## Contributing
 
-We are looking for people like you to [contribute](CONTRIBUTING.md) to this project by suggesting improvements and helping develop the Foundation for Public Code. 😊 Get started by reading our [Contributors Guide](CONTRIBUTING.md) and [how we structure our documentation](activities/documentation/index.md).
+We are looking for people like you to [contribute](CONTRIBUTING.md) to this project by suggesting improvements and helping develop the Foundation for Public Code. 😊 Get started by reading our [Contributors Guide](contributor-guides/index.md) and [how we structure our documentation](activities/documentation/index.md).
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms. Please be lovely to all other community members.
 


### PR DESCRIPTION
`contributor guides` directed to contributing.md instead of the contributor guides

fixes #703

-----
[View rendered README.md](https://github.com/publiccodenet/about/blob/Insert-correct-link/README.md)