### PR TITLE
Adding link to Odoo template from Odoo page

### DIFF
--- a/activities/codebase-stewardship/odoo-codebases.md
+++ b/activities/codebase-stewardship/odoo-codebases.md
@@ -8,6 +8,7 @@ explains: How we use Odoo for keeping track of the codebases we work with
 We use [Odoo](../tool-management/odoo.md) to keep track of the codebases we work with.
 We use the Projects app where we have set up a workflow that reflects [the codebase lifecycle](lifecycle.md).
 Each codebase is represented by a task, and each lifecycle by a column.
+When creating a task, [this template](odoo-codebase-template.md) can be used.
 
 ## Columns
 


### PR DESCRIPTION
The page that explained the Odoo process was missing the relevant template.

-----
[View rendered activities/codebase-stewardship/odoo-codebases.md](https://github.com/publiccodenet/about/blob/odoo-link/activities/codebase-stewardship/odoo-codebases.md)