### PR TITLE
Remove debrief with director from offboarding

### DIFF
--- a/activities/staff-management/offboarding.md
+++ b/activities/staff-management/offboarding.md
@@ -35,7 +35,6 @@ If the employee agrees to the terms and has no further questions, offboarding ta
 * All belongings of the Foundation for Public Code are returned or you have made an arrangement with your manager whether you can keep it or pay to keep these items
 * In case of your own device you will delete information that is either marked as SECRET or confidential
 * Inform people in the open source communities you worked with that your are leaving
-* Have a debrief with one of the directors
 
 ## Debrief (optional)
 


### PR DESCRIPTION
Having a debrief is listed as optional in the subheading below. I don't think it makes sense to have it duplicate under two subheadings. In some cases, it may make sense to debrief with someone else than a director.

Also, if we do feel a debrief with a director is not optional, perhaps the onus of this should lie with the directors? 

-----
[View rendered activities/staff-management/offboarding.md](https://github.com/publiccodenet/about/blob/Remove-debrief-with-director-from-offboarding/activities/staff-management/offboarding.md)