### PR TITLE
add guide to trainings

### DIFF
--- a/activities/trainings/index.md
+++ b/activities/trainings/index.md
@@ -8,3 +8,4 @@ Here is a list of trainings developed or used by the Foundation for Public Code:
 
 * [GitHub for newcomers](github-for-newcomers.md)
 * [Writing issues](writing-issues.md)
+* [How to write a Git commit message](https://cbea.ms/git-commit/)


### PR DESCRIPTION
I am aware it's not *quite* a training, but it is a guide, and we have another guide in the trainings index.

-----
[View rendered activities/trainings/index.md](https://github.com/publiccodenet/about/blob/add-guide-to-trainings/activities/trainings/index.md)