### PR TITLE
adds gentle art of patch review to trainings

### DIFF
--- a/activities/trainings/index.md
+++ b/activities/trainings/index.md
@@ -8,3 +8,4 @@ Here is a list of trainings developed or used by the Foundation for Public Code:
 
 * [GitHub for newcomers](github-for-newcomers.md)
 * [Writing issues](writing-issues.md)
+* [Reviewing contributions](https://sage.thesharps.us/2014/09/01/the-gentle-art-of-patch-review/)


### PR DESCRIPTION
I am aware it's not *quite* a training, but it is a guide, and we have another guide in the trainings index.

Builds on #762

-----
[View rendered activities/trainings/index.md](https://github.com/publiccodenet/about/blob/adds-gentle-art-of-patch-review-to-trainings/activities/trainings/index.md)