### PR TITLE
Specify minute on link-check.yml cron table entry

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -10,7 +10,7 @@ on:
 #             │ │ │ │ │
 #             │ │ │ │ │
 #             * * * * *
-    - cron:  '* 1 * * *' # every day at 01:00 (UTC?)
+    - cron:  '9 1 * * *' # every day at 01:09 (UTC)
 
 defaults:
   run:


### PR DESCRIPTION
Fix the crontab to run at a particular minute, rather than
imply every minute for an hour.