### PR TITLE
 Adding affiliates

### DIFF
--- a/activities/creating-affiliations/index.md
+++ b/activities/creating-affiliations/index.md
@@ -1,0 +1,17 @@
+---
+type: Index
+---
+
+# Creating affiliations
+
+The Foundation for Public Code is a [member-owned association](../member-relations/index.md).
+However, membership is only open to public organizations.
+For non-profit organizations that we want to collaborate with we can instead form an affiliation so that they become an [affiliate](../../glossary/affiliate-definition.md).
+
+[See our current affiliates](../../organization/affiliates.md).
+
+If you're interested in being affiliated with us, or have any questions, please email us at <membership@publiccode.net>.
+
+## Further Reading
+
+* Our [mission, founding principles and goals](../../organization/mission.md)

--- a/activities/creating-affiliations/index.md
+++ b/activities/creating-affiliations/index.md
@@ -5,7 +5,7 @@ type: Index
 # Creating affiliations
 
 The Foundation for Public Code is a [member-owned association](../member-relations/index.md).
-However, membership is only open to public organizations.
+Membership is only open to public organizations.
 For non-profit organizations that we want to collaborate with we can instead form an affiliation so that they become an [affiliate](../../glossary/affiliate-definition.md).
 
 [See our current affiliates](../../organization/affiliates.md).

--- a/activities/creating-affiliations/index.md
+++ b/activities/creating-affiliations/index.md
@@ -6,7 +6,7 @@ type: Index
 
 The Foundation for Public Code is a [member-owned association](../member-relations/index.md).
 Membership is only open to public organizations.
-For non-profit organizations that we want to collaborate with we can instead form an affiliation so that they become an [affiliate](../../glossary/affiliate-definition.md).
+Non-profit organizations that we collaborate with we can become [affiliates](../../glossary/affiliate-definition.md).
 
 [See our current affiliates](../../organization/affiliates.md).
 

--- a/activities/index.md
+++ b/activities/index.md
@@ -15,6 +15,7 @@ Activities that support the above as well as make staff operations work:
 * [Communication](communication/index.md)
 * [Community calls](community-calls/index.md)
 * [Conflicts of interest](conflict-of-interest/index.md)
+* [Creating affiliations](creating-affiliations/index.md)
 * [Creating partnerships](creating-partnerships/index.md)
 * [Documentation](documentation/index.md)
 * [Events](events/index.md)

--- a/glossary/affiliate-definition.md
+++ b/glossary/affiliate-definition.md
@@ -4,4 +4,4 @@ type: Resource
 
 # Affiliate
 
-A non-profit organization whose mission aligns with ours, that has committed to publicly support our work (and vice-versa).
+A non-profit organization whose mission aligns with ours, that has committed to publicly support our work (and vice-versa). [List of our affiliates](../organization/affiliates.md).

--- a/glossary/affiliate-definition.md
+++ b/glossary/affiliate-definition.md
@@ -4,4 +4,4 @@ type: Resource
 
 # Affiliate
 
-A non-profit organization whose mission aligns with ours, that has committed to publicly support our work (and vice-versa). [List of our affiliates](../organization/affiliates.md).
+A non-profit organization whose mission aligns with ours, that has committed to publicly support our work (and vice-versa). [See a list of our affiliates](../organization/affiliates.md).

--- a/organization/affiliates.md
+++ b/organization/affiliates.md
@@ -5,7 +5,7 @@ type: resource
 # Affiliates
 
 The Foundation for Public Code is a member-owned association that exists in an ecosystem of affiliates and [partners](partnerships.md).
-Affiliates are non-profit organizations whose work aligns with ours and that help us to [achieve our mission(https://about.publiccode.net/organization/mission.html).
+Affiliates are non-profit organizations whose work aligns with ours and that help us to [achieve our mission](https://about.publiccode.net/organization/mission.html).
 Read more about [becoming an affiliate](../activities/creating-affiliations/index.md).
 
 These are our affiliates:

--- a/organization/affiliates.md
+++ b/organization/affiliates.md
@@ -4,9 +4,11 @@ type: resource
 
 # Affiliates
 
-The Foundation for Public Code is a member-owned association that exists in an ecosystem of affiliates and [partners](partnerships.md). Our affiliates help us to [achieve our mission](https://about.publiccode.net/organization/mission.html). Read more about [becoming an affiliate](../activities/creating-affiliations/index.md).
+The Foundation for Public Code is a member-owned association that exists in an ecosystem of affiliates and [partners](partnerships.md).
+Affiliates are non-profit organizations whose work aligns with ours and that help us to [achieve our mission(https://about.publiccode.net/organization/mission.html).
+Read more about [becoming an affiliate](../activities/creating-affiliations/index.md).
 
-We currently have the following affiliates:
+These are our affiliates:
 
 * [OW2](https://www.ow2.org/)
 * [OASC](https://oascities.org/)

--- a/organization/affiliates.md
+++ b/organization/affiliates.md
@@ -1,0 +1,15 @@
+---
+type: resource
+---
+
+# Affiliates
+
+The Foundation for Public Code is a member-owned association that exists in an ecosystem of affiliates and [partners](partnerships.md). Our affiliates help us to [achieve our mission](https://about.publiccode.net/organization/mission.html). Read more about [becoming an affiliate](../activities/creating-affiliations/index.md).
+
+We currently have the following affiliates:
+
+* [OW2](https://www.ow2.org/)
+* [OASC](https://oascities.org/)
+* [Associació de Software Lliure Decidim](https://decidim.org) (Decidim Free Software Association)
+
+We are also founding members of [OSPO Alliance](https://ospo.zone/).

--- a/organization/index.md
+++ b/organization/index.md
@@ -15,6 +15,7 @@ This is how we're building the organization to support our mission:
 * [Members](members.md)
 * [Strategic council](strategic-council.md)
 * [Partnerships](partnerships.md)
+* [Affiliates](affiliates.md)
 * [Governance model](governance-model.md)
 * [Financial model](financial-model.md)
 * [Articles of association](articles-of-association.md) with translations in [Spanish (Español)](articles-of-association.es.md) and [Dutch (Nederlands)](articles-of-association.nl.md)

--- a/organization/partnerships.md
+++ b/organization/partnerships.md
@@ -4,6 +4,6 @@ type: resource
 
 # Partnerships
 
-The Foundation for Public Code is a member-owned association that exists in an ecosystem of partners. Our partners are integral to our ability to [achieve our mission](https://about.publiccode.net/organization/mission.html). Read more about [becoming a partner](../activities/creating-partnerships/index.md).
+The Foundation for Public Code is a member-owned association that exists in an ecosystem of partners and [affiliates](affiliates.md). Our partners are integral to our ability to [achieve our mission](https://about.publiccode.net/organization/mission.html). Read more about [becoming a partner](../activities/creating-partnerships/index.md).
 
 We currently have no partners.


### PR DESCRIPTION
Fixes #946 and #1139

Perhaps we want fewer or more cross-links between memberships, partnerships and affiliates, but this is at least a start.

If we have a template Memorandum of Understanding, it could also be added from the activity, like we have done with the partnership template.


-----
[View rendered activities/creating-affiliations/index.md](https://github.com/publiccodenet/about/blob/affiliates/activities/creating-affiliations/index.md)
[View rendered activities/index.md](https://github.com/publiccodenet/about/blob/affiliates/activities/index.md)
[View rendered glossary/affiliate-definition.md](https://github.com/publiccodenet/about/blob/affiliates/glossary/affiliate-definition.md)
[View rendered organization/affiliates.md](https://github.com/publiccodenet/about/blob/affiliates/organization/affiliates.md)
[View rendered organization/index.md](https://github.com/publiccodenet/about/blob/affiliates/organization/index.md)
[View rendered organization/partnerships.md](https://github.com/publiccodenet/about/blob/affiliates/organization/partnerships.md)