### PR TITLE
Podcast instruction tweaks

### DIFF
--- a/activities/communication/index.md
+++ b/activities/communication/index.md
@@ -20,7 +20,6 @@ These are all the activities, documents and templates for Communication.
 * [Using chat.publiccode.net](using-chat.md)
 * [Tips on communication in a remote first environment](communication-remote-first.md)
 
-
 ## Synchronous communication
 
 We meet our community regularly by [attending and running events](../events) and [workshops](../workshops), and by [hosting community calls](../community-calls).

--- a/activities/communication/index.md
+++ b/activities/communication/index.md
@@ -20,9 +20,12 @@ These are all the activities, documents and templates for Communication.
 * [Using chat.publiccode.net](using-chat.md)
 * [Tips on communication in a remote first environment](communication-remote-first.md)
 
+
 ## Synchronous communication
 
 We meet our community regularly by [attending and running events](../events) and [workshops](../workshops), and by [hosting community calls](../community-calls).
+
+We also host the [Let's Talk About Public Code livestream and podcast](https://podcast.publiccode.net/), where we interview people working with public code codebases and take audience questions. [Read about how we make podcasts](../live-streaming/).
 
 ### Community calls
 

--- a/activities/index.md
+++ b/activities/index.md
@@ -20,7 +20,7 @@ Activities that support the above as well as make staff operations work:
 * [Events](events/index.md)
 * [Explaining codebase stewardship](explaining-codebase-stewardship/index.md)
 * [Financial administration](financial-administration/index.md)
-* [Live streaming](live-streaming/index.md)
+* [Live streaming and podcasting](live-streaming/index.md)
 * [Maintenance of the Standard for Public Code](standard-maintenance/index.md)
 * [Member relations](member-relations/index.md)
 * [Membership growth](membership-growth/index.md)

--- a/activities/live-streaming/prepare-live-stream.md
+++ b/activities/live-streaming/prepare-live-stream.md
@@ -35,6 +35,7 @@ Make sure these are ready at least 3 weeks in advance:
 * Images, videos and graphs that can be used in the communication
 * Social media campaign: short video with the guest if possible
 * Shared strategy with the stakeholders involved for every interview
+* Agreement from the guest to tag them and their organization(s) on all social media platforms we both use (confirm the correct account names)
 
 ## See also
 

--- a/activities/live-streaming/prepare-live-stream.md
+++ b/activities/live-streaming/prepare-live-stream.md
@@ -36,6 +36,7 @@ Make sure these are ready at least 3 weeks in advance:
 * Social media campaign: short video with the guest if possible
 * Shared strategy with the stakeholders involved for every interview
 * Agreement from the guest to tag them and their organization(s) on all social media platforms we both use (confirm the correct account names)
+* Make sure Foundation for Public Code social media accounts follow the interviewee (if we don't already!)
 
 ## See also
 


### PR DESCRIPTION
1. I couldn't find podcasting in activities/index, so I've added the word
2. I couldn't find podcasting in activities/communications/index, so I've added LTAP.
3. I've added the instruction to get interviewee's social media handles plus their OK to tag them (so we can leverage their network)
4. Make sure we follow interviewees on social media (so we can leverage their network)

-----
[View rendered activities/communication/index.md](https://github.com/publiccodenet/about/blob/podcast-tweaks/activities/communication/index.md)
[View rendered activities/index.md](https://github.com/publiccodenet/about/blob/podcast-tweaks/activities/index.md)
[View rendered activities/live-streaming/prepare-live-stream.md](https://github.com/publiccodenet/about/blob/podcast-tweaks/activities/live-streaming/prepare-live-stream.md)