### PR TITLE
Re-add working with incubating codebases

### DIFF
--- a/activities/codebase-stewardship/incubating-codebases.md
+++ b/activities/codebase-stewardship/incubating-codebases.md
@@ -1,0 +1,16 @@
+---
+type: guide
+explains: important steps in working with a codebase in incubation
+---
+
+# Working with a codebase in incubation
+
+At least once each year the codebase stewards organizes a meeting with the codebase community to do a forward look.
+The meeting should cover what the ambitions of the community related to meeting more requirements in the Standard for Public Code will be the next year.
+At the latest, a forward look like this should happen about three months before the [general assembly](../../organization/governance-model.md#general-assembly).
+It should be clearly communicated that the information collected in the forward look will feed into a report for the general assembly.
+The forward look could either be part of a regular product steering meeting if such exist, or be a separate meeting.
+Afterwards, the codebase stewards prepares a "state of the codebases", covering all codebases in stewardship, to the general assembly so that the members can make informed decisions during it.
+Of particular interest for the codebase stewards is if the general assembly wants to prioritize a codebase for strategic reasons, even if compliance with the Standard for Public Code is unlikely the coming year.
+Such decision will give the codebase stewards the mandate to continue stewarding the incubated codebase.
+Alternatively, the members can decide that stop the incubation of a codebase that doesn't present any renewed ambitions and simply end the lifecycle.

--- a/activities/codebase-stewardship/index.md
+++ b/activities/codebase-stewardship/index.md
@@ -69,6 +69,7 @@ It is useful even as a handbook when trying to guide a community through any sit
 * [Explaining what codebase stewardship is](../explaining-codebase-stewardship/index.md) - often needed when meeting new communities to help them understand what we do
 * [Maintenance of the Standard for Public Code](../standard-maintenance/index.md) - we continuously develop the standard and are tending to incoming issues and have community calls
 * [Supporting governance](../supporting-codebase-governance/) - crucially needed for codebase communities that haven't got their first collaborator yet
+* [Working with codebases in incubation](incubating-codebases.md) - important steps
 * [Workshops](../workshops/index.md) - we often help our communities learn and understand their needs through workshops
 * [Tool guidance](../tool-management/index.md) - a list of the tools that we currently have at our disposal
 


### PR DESCRIPTION
This was removed as part of #1129, and now re-added as its own guide.

Co-authored-by: Jan Ainali <ainali.jan@gmail.com>