### PR TITLE
Fix typos and consistent periods

### DIFF
--- a/organization/board-of-directors-meetings/2022-04-06-minutes.md
+++ b/organization/board-of-directors-meetings/2022-04-06-minutes.md
@@ -12,12 +12,12 @@ type: Resource
    1. Action: Eric and Boris to renegotiate with Multiple Ventures BV for services in 2022
       1. Completed
 2. For discussion:
-   1. Setting up Italian salary administration has still not been successful.
-      1. Eric to propose a new services agreement to continue as freelancer.
-      2. Eric to end the process of setting up the salary administration.
+   1. Setting up Italian salary administration has still not been successful
+      1. Eric to propose a new services agreement to continue as freelancer
+      2. Eric to end the process of setting up the salary administration
    1. Letter from the chief executive indicated they can’t fulfil their role and their request for a new role
-      1. Eric, supported by Ben, to offer Boris a new role focussed on developing European relationships.
-      2. Eric, with Boris, In a separate meeting we will make sure that for all the roles of the chief executive someone is responsible in the short term.
+      1. Eric, supported by Ben, to offer Boris a new role focussed on developing European relationships
+      2. Eric, with Boris, in a separate meeting we will make sure that for all the roles of the chief executive someone is responsible in the short term
       3. We’ll start looking for a new chief executive
 3. Approve meeting minutes:
    1. Ben Cerveny: Approved

--- a/organization/board-of-directors-meetings/2022-04-26-minutes.md
+++ b/organization/board-of-directors-meetings/2022-04-26-minutes.md
@@ -2,7 +2,7 @@
 type: Resource
 ---
 
-# Board meeting April 28th 2022
+# Board meeting April 26th 2022
 
 Attendees:
 


### PR DESCRIPTION
We usually don't have periods at all in the numbered list in the meeting minutes, so I removed the few that were present in the last meeting minutes.

-----
[View rendered organization/board-of-directors-meetings/2022-04-06-minutes.md](https://github.com/publiccodenet/about/blob/board-minutes-typos/organization/board-of-directors-meetings/2022-04-06-minutes.md)
[View rendered organization/board-of-directors-meetings/2022-04-26-minutes.md](https://github.com/publiccodenet/about/blob/board-minutes-typos/organization/board-of-directors-meetings/2022-04-26-minutes.md)