### PR TITLE
Move managing sick leave to /staff-management

### DIFF
--- a/activities/staff-management/approving-leave.md
+++ b/activities/staff-management/approving-leave.md
@@ -16,3 +16,4 @@ A leave request email is submitted through the personal Tentoo account of the em
 ## Further reading
 
 * [Staff leave guide](../staff-information/leave.md)
+* [Sickness leave management](/sick-leave.md)

--- a/activities/staff-management/index.md
+++ b/activities/staff-management/index.md
@@ -13,6 +13,7 @@ Staff management is the policies and systems for managing people within the orga
 * [Probation](probation.md)
 * [Expenses](../staff-information/expense.md)
 * [Approving leave](approving-leave.md)
+* [Managing sick leave](sick-leave.md)
 
 Elsewhere:
 

--- a/activities/staff-management/sick-leave.md
+++ b/activities/staff-management/sick-leave.md
@@ -1,0 +1,37 @@
+---
+type: Guide
+explains: how to manage staff sick leave
+---
+
+## Managing sick leave
+
+Staff report that they are sick as per our [sickness policy](../staff-information/sickness.md) the morning they are sick.
+
+### Short-term sick leave management
+
+The chief executive immediately reports the sick leave in [the portal of our absenteeism insurance](https://mijnwerkgeversportaal.acumen.nl/index3.html).
+As soon as the employee is better it needs to be reported in the same portal. This can also be done retroactively if the chief executive is not present on the day the employee goes back to work.
+
+### Long-term sick leave management
+
+The Foundation for Public Code will always work in accordance with the law ([Wet Verbetering Poortwachter](https://www.arboportaal.nl/onderwerpen/wet-verbetering-poortwachter)). Below is a non-authoritative and supporting summary in English.
+
+Foundation for Public Code staff are always paid while sick (100% the first year of sickness and 70% the second year).
+
+When an employee is sick for a longer time [an ARBO (company) doctor](https://www.arboned.nl/en/absence-support/company-doctor-as-specialist) will be involved. Our ARBO service is [RegioPoortwachters](https://www.regiopoortwachters.nl/).
+
+A case manager from RegioPoortwachters will reach out to inquire about the sick employee approximately 10 days after the initial sickness report in the insurance portal. The ARBO service portal is integrated with our insurance portal.
+
+The ARBO service will plan a meeting between the employee and an ARBO doctor to assess the employee's situation. Based on the assessment, the employee will start reintegration when their situation allows. The ARBO service will draft a [reintegration plan (plan van aanpak)](https://business.gov.nl/regulation/working-conditions-employees/) for the employee. This plan should include the procedures all involved parties must follow. The chief executive must approve the plan.
+
+### Reintegration management
+
+The ARBO service case manager is the main contact person between the sick employee and the chief executive, and will send updates regularly. It's important to track the percentage of sickness vs reintegration hours in the insurance portal. For example, if an employee is working 20%, this means they are sick for 80%. This needs to be kept up-to-date as the insurance payout is based on the percentage of sickness.
+
+Approximately 1.5 months after the initial sickness report, the insurance company will request the sick employee's payslips to prepare for the insurance payout. The director will receive an email about this. [Payslips are available to admins in Tentoo](https://about.publiccode.net/activities/tool-management/tentoo.html).
+
+### UWV (Uitvoeringsinstituut Werknemersverzekeringen)
+
+If the employee has been sick for more than three quarters of a year, [it must be reported to the UWV](https://www.uwv.nl/werkgevers/werknemer-is-ziek/loondoorbetaling/werknemer-is-langdurig-ziek/index.aspx). The 42nd week report must be submitted no later than the first working day after the 42nd week of illness.
+
+If the employee has not completed reintegration after a year, a one year evaluation must take place. During this evaluation the director and the employee discuss whether the integration approach has been successful, and a report is prepared. The ARBO case manager will be available for guidance and instructions.


### PR DESCRIPTION
Managing sick leave was previously in staff information, which is no longer the correct home for it.