### PR TITLE
Remove reference to Gchat 

### DIFF
--- a/activities/staff-information/remote-working.md
+++ b/activities/staff-information/remote-working.md
@@ -12,7 +12,7 @@ Everyone is free to work from home as long as they coordinate this with their co
 ## Information sharing
 
 1. Always CC the relevant group email. Our groups are: stewards, membership, events, giving, invoices, hr, security, Amsterdam-office and everyone (includes everyone with an @publiccode.net email account).
-2. We'll use [chat.publiccode.net](/../communication/using-chat.md) instead of Gchat for office conversation. The channels should make it easier for someone in a different time zone to catch up with relevant conversations.
+2. We'll use [chat.publiccode.net](/../communication/using-chat.md) for office conversation. The channels should make it easier for someone in a different time zone to catch up with relevant conversations.
 3. We're going to try to work Odoo-first for our secret work, so that we all have access and contribute to the same structured information.
 
 ## Meetings


### PR DESCRIPTION
It only made sense just after the move and now it only looks confusing.

-----
[View rendered activities/staff-information/remote-working.md](https://github.com/publiccodenet/about/blob/remove-gchat-reference/activities/staff-information/remote-working.md)