### PR TITLE
Remove outdated process

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -16,4 +16,3 @@ Staff at the Foundation for Public Code will review the pull request and it can 
 ## Publishing changes from `develop` to `main`
 
 All of the changes in `develop` are agreed upon by all directors of the Foundation for Public Code before they can be [published on About](/activities/documentation/merge-develop-into-main.md), and are accepted as 'truth'.
-This usually happens in the weekly directors meeting.


### PR DESCRIPTION
I think this fixes #1117 

I believe it's okay that the README states that we aim to publish on Mondays, even if we often miss it. 
And the how-to on About doesn't need to say when, we just consult it whenever it's initiated.

-----
[View rendered GOVERNANCE.md](https://github.com/publiccodenet/about/blob/update-repository-governance/GOVERNANCE.md)