### PR TITLE
Simplifying blog process

### DIFF
--- a/activities/communication/blogging.md
+++ b/activities/communication/blogging.md
@@ -91,9 +91,7 @@ Example:
 Commit your changes and create a pull request.
 Tag the communications coordinator plus any other colleagues whose review you'd like on the pull request for your blogpost for a final proofread.
 
-Once approved, merge your pull request.
-
-To publish the new content, you'll have to create a release branch and [merge develop into main](../documentation/merge-develop-into-main.md).
+Once approved, your pull request will be merged and published.
 
 ## Further reading
 


### PR DESCRIPTION
Merge directly to main, see publiccodenet/blog#345.

Also, I don't think external contributors can merge themselves, so I changed it so they don't think they should push the button.

-----
[View rendered activities/communication/blogging.md](https://github.com/publiccodenet/about/blob/simplify-blog-process/activities/communication/blogging.md)