### PR TITLE
Align scripts/ with the Standard repo

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -25,4 +25,5 @@ jobs:
         with:
           ruby-version: '2.7'
       - run: bundle install
+      - run: ./script/test-markdown.sh
       - run: ./script/test-with-link-check.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,6 @@ jobs:
         with:
           ruby-version: '2.7'
       - run: bundle install
-      - run: ./script/cibuild.sh
+      - run: ./script/test-markdown.sh
+      - run: ./script/test-without-link-check.sh
+      - run: ./script/check-new-links.sh

--- a/script/cibuild.sh
+++ b/script/cibuild.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-./script/test-without-link-check.sh && ./script/check-new-links.sh

--- a/script/serve.sh
+++ b/script/serve.sh
@@ -1,7 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 
-# This sets the right variable for the GitHub pages build
-# so it's not confused when it can't get the repository information from GitHub
-PAGES_REPO_NWO=publiccodenet/standard \
+# jekyll build defaults to "origin" unless PAGES_REPO_NWO is set
+# if there is no "origin" branch and PAGES_REPO_NWO is not set
+# then default to publiccodenet/blog
+if [ "_$(git remote | grep origin)_" != "_origin_" ] &&
+   [ "_${PAGES_REPO_NWO}_" == "__" ]; then
+export PAGES_REPO_NWO=publiccodenet/blog
+fi
 
 bundle exec jekyll serve --livereload

--- a/script/test-all.sh
+++ b/script/test-all.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# This script is provided for local development,
+# it is not used by continuous integration
+
+# $ help set
+#      -e  Exit immediately if a command exits with a non-zero status.
+#      -x  Print commands and their arguments as they are executed.
+set -x
+set -e
+
+./script/test-markdown.sh
+./script/test-without-link-check.sh
+./script/check-new-links.sh
+./script/test-with-link-check.sh

--- a/script/test-markdown.sh
+++ b/script/test-markdown.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Lint markdown using the Markdownlint gem with the default ruleset except for:
+# MD007 Unordered list indentation: we allow sub-lists to also have bullets
+# MD013 Line length: we allow long lines
+# MD029 Ordered list item prefix: we allow lists to be sequentially numbered
+#
+# Additionally, we have these violations which should be resolved:
+# MD028 Blank line inside blockquote
+#
+bundle exec mdl -r ~MD007,~MD013,~MD029,~MD028 -i -g '.'

--- a/script/test-without-link-check.sh
+++ b/script/test-without-link-check.sh
@@ -1,18 +1,22 @@
 #!/usr/bin/env bash
 set -e # halt script on error
 
-# Lint markdown using the Markdownlint gem with the default ruleset except for:
-# MD013 Line length: we allow long lines
-# MD028 Blank line inside blockquote: we allow blank lines between block quotes (to permit consecutive quotations by different people)
-# MD029 Ordered list item prefix: we allow lists to be sequentially numbered
-bundle exec mdl -r ~MD013,~MD028,~MD029 -i -g '.'
+# jekyll build defaults to "origin" unless PAGES_REPO_NWO is set
+# if there is no "origin" branch and PAGES_REPO_NWO is not set
+# then default to publiccodenet/blog
+if [ "_$(git remote | grep origin)_" != "_origin_" ] &&
+   [ "_${PAGES_REPO_NWO}_" == "__" ]; then
+export PAGES_REPO_NWO=publiccodenet/blog
+fi
 
 # Build the site
 bundle exec jekyll build
 
 # Check for broken links and missing alt tags:
 # jekyll does not require extentions like HTML
-#  --disable-external to only check internal links
+# run only "ScriptCheck" and "ImageCheck"; skip "LinkCheck"
+# set an extra long timout for test-servers with poor connectivity
+# ignore request rate limit errors (HTTP 429)
 # using the files in Jekylls build folder
 bundle exec htmlproofer \
     --assume-extension \


### PR DESCRIPTION
Updating the Blog repo scripts to match the Standard,
a few differences in URLs to ignore and markdown violations,
but very close.