### PR TITLE
Fix two tiny typos

### DIFF
--- a/activities/codebase-stewardship/odoo-codebases.md
+++ b/activities/codebase-stewardship/odoo-codebases.md
@@ -62,7 +62,7 @@ Codebases may also move to Backburner or Archive at any time.
 * Who is in the community?
 * Where do they speak?
 * How is the codebase governed?
-* Does it look healthy?"
+* Does it look healthy?
 
 #### Scalability
 

--- a/organization/annual-reports/index.md
+++ b/organization/annual-reports/index.md
@@ -10,7 +10,7 @@ The Foundation for Public Code publishes a 2-part annual report each year. It co
 
 We're publishing our financial report provisionally. The General Assembly will confirm the accounts after review by an independent expert, which we're still waiting for.
 
-* [financial report [PDF]](https://files.publiccode.net/nextcloud/index.php/s/ccZ7PnRtjiEtgs6))
+* [financial report [PDF]](https://files.publiccode.net/nextcloud/index.php/s/ccZ7PnRtjiEtgs6)
 
 ## 2019-2020
 


### PR DESCRIPTION
Removing ending `"` and `)` that lacked starting ones.

-----
[View rendered activities/codebase-stewardship/odoo-codebases.md](https://github.com/publiccodenet/about/blob/two-tiny-typos/activities/codebase-stewardship/odoo-codebases.md)
[View rendered organization/annual-reports/index.md](https://github.com/publiccodenet/about/blob/two-tiny-typos/organization/annual-reports/index.md)