### PR TITLE
Pin html proofer to ~>3.19 to unbreak build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 gem 'github-pages', group: :jekyll_plugins
-gem 'html-proofer'
+gem 'html-proofer', '~>3.19'
 gem 'chef-utils'
 gem 'mdl'


### PR DESCRIPTION
Newer html-proofer (4.0.1) fails with:

htmlproofer 4.0.1 | Error:  invalid option: --typhoeus-config

https://github.com/publiccodenet/about/runs/7313825567?check_suite_focus=true

and complains about some of the jekyll generated html

https://github.com/publiccodenet/about/runs/7299381705?check_suite_focus=true