### PR TITLE
Remove year from policy plan link

### DIFF
--- a/organization/index.md
+++ b/organization/index.md
@@ -23,7 +23,7 @@ This is how we're building the organization to support our mission:
 * [Staff](staff.md)
 * [Remuneration policy](remuneration-policy.md)
 * [Roadmap](roadmap.md)
-* [Policy plan 2019-2022](policy-plan.md)
+* [Policy plan](policy-plan.md)
 * [Measurable goals December 2020-March 2021](measurable-goals.md)
 * [Board meeting minutes](board-of-directors-meetings/)
 * [General assemblies minutes](general-assemblies/)


### PR DESCRIPTION
As the policy plan is an evolving "living" document updated by decisions
of the general assembly, we will not have separate versions per year or
period.

Rather than update the year on the link, this removes it.

-----
[View rendered organization/index.md](https://github.com/publiccodenet/about/blob/policy-plan-living-doc/organization/index.md)