### PR TITLE
Fix webrick LoadError

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ gem 'github-pages', group: :jekyll_plugins
 gem 'html-proofer', '~>3.19'
 gem 'chef-utils'
 gem 'mdl'
+
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
Fixes `require': cannot load such file -- webrick (LoadError)

```
eric@dione:~/src/about.publiccode.net$ script/serve.sh 
Configuration file: /home/eric/src/about.publiccode.net/_config.yml
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
            Source: /home/eric/src/about.publiccode.net
       Destination: /home/eric/src/about.publiccode.net/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
      Remote Theme: Using theme publiccodenet/jekyll-theme
       Jekyll Feed: Generating feed for posts
   GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data.
                    done in 10.305 seconds.
 Auto-regeneration: enabled for '/home/eric/src/about.publiccode.net'
/home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve/servlet.rb:3:in `require': cannot load such file -- webrick (LoadError)
	from /home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve/servlet.rb:3:in `<top (required)>'
	from /home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:184:in `require_relative'
	from /home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:184:in `setup'
	from /home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:102:in `process'
	from /home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:93:in `block in start'
	from /home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:93:in `each'
	from /home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:93:in `start'
	from /home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:75:in `block (2 levels) in init_with_program'
	from /home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
	from /home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
	from /home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
	from /home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
	from /home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
	from /home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/exe/jekyll:15:in `<top (required)>'
	from /home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/bin/jekyll:25:in `load'
	from /home/eric/src/about.publiccode.net/vendor/bundle/ruby/3.0.0/bin/jekyll:25:in `<main>'
eric@dione:~/src/about.publiccode.net(1)$ 
```