### PR TITLE
Ignore miro in link check

### DIFF
--- a/script/test-with-link-check.sh
+++ b/script/test-with-link-check.sh
@@ -21,6 +21,7 @@ bundle exec jekyll build
 # * wetten.overheid.nl : does not serve to scripts
 # * opensource.org : gives "failed: 503 No error" when run as GitHub workflow
 # * lists.publiccode.net/mailman/ : gives 500, 503 errors to scripts
+# * help.miro.com/hc/en-us : gives "failed: 403 No error" from GitHub workflow
 URL_IGNORE_REGEXES="\
 /github\.com\/.*\/edit\//\
 ,/docs\.github\.com\/en\//\
@@ -28,6 +29,7 @@ URL_IGNORE_REGEXES="\
 ,/wetten\.overheid\.nl/\
 ,/opensource\.org/\
 ,/lists\.publiccode\.net\/mailman/\
+,/help\.miro\.com\/hc\/en-us/\
 "
 
 # Check for broken links and missing alt tags:


### PR DESCRIPTION
Even though this runs fine from my laptop,
Link checks have been regularly failing with:

```
Checking 401 external links...
- ./_site/activities/tool-management/miro.html
  *  External link https://help.miro.com/hc/en-us failed: 403 No error

HTML-Proofer found 1 failure!
Ran on 308 files!
```

See:
https://github.com/publiccodenet/about/actions/workflows/link-check.yml