### PR TITLE
Adds ospo page

### DIFF
--- a/OSPO.md
+++ b/OSPO.md
@@ -15,9 +15,9 @@ We help people collaborate on public code. Our focus is on the communities aroun
 
 ## Then we can help you, your organization's staff, and (potentially) the wider codebase community:
 
-* clarify and improve governance around the codebase (see governance links)
-* develop good working practices that make collaboration easier and improve the quality of the codebase (see standard link)
-* work on the communication, culture change and organizational values that come with collaboration in the open (see we helped signalen get started, openzaak consultation, and PZH go open)
+* [clarify and improve governance around the codebase](activities/supporting-codebase-governance)
+* [develop good working practices that make collaboration easier and improve the quality of the codebase](standard.publiccode.net)
+* [work on the communication, culture change and organizational values that come with collaboration in the open](publiccode.net/codebase-stewardship)
 
 Email us at <info@publiccode.net> to start the discussion.
 

--- a/OSPO.md
+++ b/OSPO.md
@@ -1,0 +1,34 @@
+---
+type: Resource
+---
+
+# Government Open Source Programme Offices: We can help you collaborate with the communities around a codebases
+
+We help people collaborate on public code. Our focus is on the communities around a given codebase.
+
+## If your open source progam office (OSPO) or organization is planning to:
+
+* open up one of your codebases for other people to reuse and contribute to
+* use an existing codebase to the extent that it becomes important to your organization, and you'd like to participate in its governance
+* contribute your work back into a codebase (upstream) 
+* work with third parties (especially vendors) to do any of the above
+
+## Then we can help you, your organization's staff, and (potentially) the wider codebase community:
+
+* clarify and improve governance around the codebase (see governance links)
+* develop good working practices that make collaboration easier and improve the quality of the codebase (see standard link)
+* work on the communication, culture change and organizational values that come with collaboration in the open (see we helped signalen get started, openzaak consultation, and PZH go open)
+
+Email us at <info@publiccode.net> to start the discussion.
+
+## Getting started with a government OSPO
+
+If you're looking for more general OSPO advice or government digital transformation tips, we recommend:
+
+* [The OSPO – A new tool for digital government](https://openforumeurope.org/publications/the-ospo-a-new-tool-for-digital-government/) by Open Forum Europe and the OSPO Alliance
+* [OSPO.zone](https://ospo.zone/) by the OSPO Alliance (we're a founding member)
+* [TODO Group community and resources](https://github.com/todogroup) by the TODO Group
+* [Open source in government: creating the conditions for success](https://public.digital/2021/06/21/open-source-in-government-creating-the-conditions-for-success) by Public Digital
+* [Building and reusing open source tools for government](https://www.newamerica.org/digital-impact-governance-initiative/reports/building-and-reusing-open-source-tools-government/) by the New America Foundation
+* [Guidelines for sustainable open source communities in the public sector](https://joinup.ec.europa.eu/collection/open-source-observatory-osor/guidelines-creating-sustainable-open-source-communities) by the European Commission's Open Source Observatory
+

--- a/OSPO.md
+++ b/OSPO.md
@@ -15,9 +15,9 @@ We help people collaborate on public code. Our focus is on the communities aroun
 
 ## Then we can help you, your organization's staff, and (potentially) the wider codebase community:
 
-* [clarify and improve governance around the codebase](activities/supporting-codebase-governance)
-* [develop good working practices that make collaboration easier and improve the quality of the codebase](standard.publiccode.net)
-* [work on the communication, culture change and organizational values that come with collaboration in the open](publiccode.net/codebase-stewardship)
+* [clarify and improve governance around the codebase](activities/supporting-codebase-governance/index.md)
+* [develop good working practices that make collaboration easier and improve the quality of the codebase](https://standard.publiccode.net)
+* [work on the communication, culture change and organizational values that come with collaboration in the open](https://publiccode.net/codebase-stewardship)
 
 Email us at <info@publiccode.net> to start the discussion.
 


### PR DESCRIPTION
Note - this page is currently not linked from anywhere. Do we want to keep it that way? Perhaps with 'floating' in the front matter so we know it's intentional/can bulk search for these in the future?

-----
[View rendered OSPO.md](https://github.com/publiccodenet/about/blob/adds_OSPO_page/OSPO.md)