### PR TITLE
Do not linkcheck belastingdienst.nl, fail from workflow

### DIFF
--- a/script/test-with-link-check.sh
+++ b/script/test-with-link-check.sh
@@ -22,6 +22,7 @@ bundle exec jekyll build
 # * opensource.org : gives "failed: 503 No error" when run as GitHub workflow
 # * lists.publiccode.net/mailman/ : gives 500, 503 errors to scripts
 # * help.miro.com/hc/en-us : gives "failed: 403 No error" from GitHub workflow
+# * belastingdienst.nl : "failed: response code 0 means something's wrong."
 URL_IGNORE_REGEXES="\
 /github\.com\/.*\/edit\//\
 ,/docs\.github\.com\/en\//\
@@ -30,6 +31,7 @@ URL_IGNORE_REGEXES="\
 ,/opensource\.org/\
 ,/lists\.publiccode\.net\/mailman/\
 ,/help\.miro\.com\/hc\/en-us/\
+,/belastingdienst\.nl/\
 "
 
 # Check for broken links and missing alt tags:


### PR DESCRIPTION
https://github.com/publiccodenet/about/actions/workflows/link-check.yml

The links have been serving "failed: response code 0" in the GitHub workflow, even though they work when run from my laptop ....

Perhaps the site has added some sort of new bot detection or DDos protection.