### PR TITLE
Update online section with Excalidraw and image links

### DIFF
--- a/activities/supporting-codebase-governance/game/run-governance-game-workshop.md
+++ b/activities/supporting-codebase-governance/game/run-governance-game-workshop.md
@@ -25,8 +25,9 @@ The game can be enhanced by having a large paper first placed on the table that 
 
 ### Preparing an online session
 
-You can also use digitized versions of the cards in a tool like Google slides or Miro.
-Make a copy of the template ([Google slides](https://docs.google.com/presentation/d/1irBjBKMPNsNkGTFNjk4thYizDYrqYfgBJZTdj1hw19c/edit?usp=sharing)) and make sure it is accessible and editable by anyone with the link.
+You can also use digitized versions of the cards in a tool like Excalidraw, Google slides or Miro.
+Make a copy of one of the templates ([Excalidraw](https://link.excalidraw.com/readonly/3tTXUKAX0t4sFqlaFcfq), [Google slides](https://docs.google.com/presentation/d/1irBjBKMPNsNkGTFNjk4thYizDYrqYfgBJZTdj1hw19c/edit?usp=sharing)) and make sure it is accessible and editable by anyone with the link.
+If you use another tool, you can find image files for all the cards attached to [the latest release](https://github.com/publiccodenet/governance-game/releases/latest).
 Set up a video chat to enable discussions between the participants.
 Highlight to the participants that a large, or even a second, screen will make the game easier to follow.
 


### PR DESCRIPTION
This adds the Excalidraw link and informs where one can get all the images.
I intentionally didn't make it an Excalidraw handbook, stating every command one needs to do to make a copy, as that would make us more reliant on the user interface to stay the same.