### PR TITLE
Add etherpad to tool list

### DIFF
--- a/activities/tool-management/etherpad.md
+++ b/activities/tool-management/etherpad.md
@@ -8,11 +8,12 @@ type: resource
 
 We have an Etherpad lite running at [write.publiccode.net](https://write.publiccode.net/).
 
-### What to do with people's data
+## What to do with people's data
 
-A user can provide their name or a pseudonym as author. All authorships can be cleared from the current version but it will still be shown in the Timeslider functionality. 
+A user can provide their name or a pseudonym as author.
+All authorships can be cleared from the current version but it will still be shown in the Timeslider functionality.
 
-### How we handle code of conduct violations
+## How we handle code of conduct violations
 
 By default, the full [Foundation for Public Code code of conduct](../../CODE_OF_CONDUCT.md) applies to all of our pads.
 

--- a/activities/tool-management/etherpad.md
+++ b/activities/tool-management/etherpad.md
@@ -1,0 +1,9 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2023 The Foundation for Public Code <info@publiccode.net>
+type: resource
+---
+
+# Etherpad
+
+We have an Etherpad lite running at [write.publiccode.net](https://write.publiccode.net/).

--- a/activities/tool-management/etherpad.md
+++ b/activities/tool-management/etherpad.md
@@ -7,3 +7,15 @@ type: resource
 # Etherpad
 
 We have an Etherpad lite running at [write.publiccode.net](https://write.publiccode.net/).
+
+### What to do with people's data
+
+A user can provide their name or a pseudonym as author. All authorships can be cleared from the current version but it will still be shown in the Timeslider functionality. 
+
+### How we handle code of conduct violations
+
+By default, the full [Foundation for Public Code code of conduct](../../CODE_OF_CONDUCT.md) applies to all of our pads.
+
+## Etherpad management
+
+The Etherpad is hosted on a VPS at [Maadix](https://maadix.net/en), an independent service provider.

--- a/activities/tool-management/index.md
+++ b/activities/tool-management/index.md
@@ -33,6 +33,7 @@ Our guidance covers:
 
 * [1password](1password.md) (password management)
 * [Docusign](docusign.md) (contract management)
+* [Etherpad](etherpad.md) (shared text editing)
 * [Excalidraw](excalidraw.md) (online collaborative whiteboard)
 * [GitHub](github.md) (version control and codebase management)
 * [Google Workspace](google-workspace.md) (email, calendaring and internal document management)


### PR DESCRIPTION
This adds the most bare skeleton for where to put more information.

Guidance on usage and tool administration should be added.

See: #1363