### PR TITLE
Updates pitching page

### DIFF
--- a/activities/communication/pitching.md
+++ b/activities/communication/pitching.md
@@ -117,7 +117,7 @@ Why are you an association when you're called a Foundation?
 
 As a reminder, our goals are:
 
-* to stay member owned forever (and only wholly publicly owned organizations can be members)
+* to stay focus on public interest
 * to make it hard for a corporate interest to dominate the Foundation for Public Code (so we can't 'sell out')
 
 Read more about [why we're an association named a foundation](https://github.com/publiccodenet/blog/issues/36).

--- a/activities/communication/pitching.md
+++ b/activities/communication/pitching.md
@@ -61,7 +61,7 @@ We have different perspectives on open source:
 
 We should reflect our [founding principles](https://about.publiccode.net/organization/mission.html#founding-principles) in our pitches.
 
-Avoid: "we think or we believe" [open source is better]
+Avoid: "we think or we believe" [open source is better].
 Instead, describe what we do: "we help public organizations [share collaborative software].
 
 ### Contextual knowledge

--- a/activities/communication/pitching.md
+++ b/activities/communication/pitching.md
@@ -99,11 +99,6 @@ How are you funded?
 * The runway was provided by a philanthropic grant, with the goal that the members of the association (which must be wholly publicly owned, like cities, provinces or states) pool the money and decide which codebases we should work on. In the long term, we thought we would be funded by a combination of member dues and philanthropic gifts.
 * After we complete the transition to a global international organization with local chapters, we expect our funds will come from a combination of structural funding by provincial, national or supranational governments (to multiply stewardship work with our partners), grants from structural philanthropic sources, and individual philanthropic gifts.
 
-What about donor influence - do you have a conflict of interest?
-
-* No. We accept philanthropic donations, but only members (publicly owned organizations) can vote in the general assembly or appoint the board of directors.
-* No. We also don't work for hire; you can't pay the Foundation to do work.
-
 Is now the right time and place? What about incumbent vendors?
 
 * We'll have to see, but the idea is that we'll work with the vendors to get them more work as more public organizations start using the same codebase.
@@ -116,7 +111,7 @@ Why are you an association when you're called a Foundation?
 
 As a reminder, our goals are:
 
-* to stay focus on public interest
+* to stay focused on public interest
 * to make it hard for a corporate interest to dominate the Foundation for Public Code (so we can't 'sell out')
 
 Read more about [why we're an association named a foundation](https://github.com/publiccodenet/blog/issues/36).

--- a/activities/communication/pitching.md
+++ b/activities/communication/pitching.md
@@ -30,7 +30,6 @@ For people with government experience or interest:
 For the general public, assuming no prior technology or government experience:
 
 * "Today, municipalities and government agencies have small pieces of software to provide services, and every municipality has their own. But rather than contracting to consulting companies to build their version, municipalities could pool together and make an open source one. Then each municipality only has to customise it to what they need. We help municipalities work together."
-
 * "We help cities build and maintain public purpose, open source software together."
 
 For cocktail party audiences, assuming no interest at all:

--- a/activities/communication/pitching.md
+++ b/activities/communication/pitching.md
@@ -89,6 +89,11 @@ When talking to someone who doesn't trust government officials' ethics or effici
 
 These are follow up questions we've received, and answers staff have given.
 
+What's currently happening with the Foundation?
+
+* We're in the middle of changing our legal form to become a global umbrella organization with local chapters. We will no longer have public organizations as association members because this was too difficult for most interested organizations; instead, we plan to work with public organizations as partners. Our mission, expertise and core activities (codebase stewardship, capability building in public organizations) have not changed. Exactly what each local chapter will focus on will depend on local needs and opportunities, as will their funding model. We already have a North America chapter, and plan one in Europe.
+* We'd love your advice on how we can make this successful. We hope the transition will be complete by the end of 2023.
+
 Are you a lobbying org? Are you the same as the FSFE?
 
 * No. We work with the organizations that have already decided to use open source. We're non-partisan and can't lobby, as per our founding principles and non-profit status.
@@ -97,7 +102,7 @@ Are you a lobbying org? Are you the same as the FSFE?
 How are you funded?
 
 * The runway was provided by a philanthropic grant, with the goal that the members of the association (which must be wholly publicly owned, like cities, provinces or states) pool the money and decide which codebases we should work on. In the long term, we thought we would be funded by a combination of member dues and philanthropic gifts.
-* After we complete the transition to a global international organization with local chapters, we expect our funds will come from a combination of structural funding by provincial, national or supranational governments (to multiply stewardship work with our partners), grants from structural philanthropic sources, and individual philanthropic gifts.
+* After we complete the transition to a global international organization with local chapters, we expect our funds will come from a combination of structural funding by provincial, national or supranational governments (to multiply our stewardship work with our partners), grants from structural philanthropic sources, and individual philanthropic gifts.
 
 Is now the right time and place? What about incumbent vendors?
 

--- a/activities/communication/pitching.md
+++ b/activities/communication/pitching.md
@@ -100,11 +100,6 @@ Where does your money come from?
 * We're member-funded, but how to get members for a new association is a chicken and egg problem, so we started with a philanthropic grant.
 * In the future, member dues will pay for our core activities. Our expansion and our research and development may be philanthropically funded - this will allow us to develop new stewardship activities, and design and test new assets before we apply these to core activities, which are effectively taxpayer funded.
 
-What about donor influence - do you have a conflict of interest?
-
-* No. We accept philanthropic donations, but only members (publicly owned organizations) can vote in the general assembly or appoint the board of directors.
-* No. We also don't work for hire; you can't pay the Foundation to do work.
-
 Is now the right time and place? What about incumbent vendors?
 
 * We'll have to see, but the idea is that we'll work with the vendors to get them more work as more public organizations start using the same codebase.

--- a/activities/communication/pitching.md
+++ b/activities/communication/pitching.md
@@ -62,7 +62,7 @@ We have different perspectives on open source:
 We should reflect our [founding principles](https://about.publiccode.net/organization/mission.html#founding-principles) in our pitches.
 
 Avoid: "we think or we believe" [open source is better]
-Instead, describe what we do: "we help municipalities [share collaborative software].
+Instead, describe what we do: "we help public organizations [share collaborative software].
 
 ### Contextual knowledge
 

--- a/activities/communication/pitching.md
+++ b/activities/communication/pitching.md
@@ -91,8 +91,11 @@ These are follow up questions we've received, and answers staff have given.
 
 What's currently happening with the Foundation?
 
-* We're in the middle of changing our legal form to become a global umbrella organization with local chapters. We will no longer have public organizations as association members because this was too difficult for most interested organizations; instead, we plan to work with public organizations as partners. Our mission, expertise and core activities (codebase stewardship, capability building in public organizations) have not changed. Exactly what each local chapter will focus on will depend on local needs and opportunities, as will their funding model. We already have a North America chapter, and plan one in Europe.
-* We'd love your advice on how we can make this successful. We hope the transition will be complete by the end of 2023.
+* We're in the middle of changing our legal form to become a global umbrella organization with local chapters. We will no longer have public organizations as association members because this was too difficult for most interested organizations; instead, we plan to work with public organizations as partners. 
+
+    Our mission, expertise and core activities (codebase stewardship, capability building in public organizations) have not changed. Exactly what each local chapter will focus on will depend on local needs and opportunities, as will their funding model. We already have a North America chapter, and plan one in Europe.
+
+    We hope the transition will be complete by the end of 2023. We'd love your advice on how we can make this successful. 
 
 Are you a lobbying org? Are you the same as the FSFE?
 

--- a/activities/communication/pitching.md
+++ b/activities/communication/pitching.md
@@ -94,11 +94,15 @@ Are you a lobbying org? Are you the same as the FSFE?
 * No. We work with the organizations that have already decided to use open source. We're non-partisan and can't lobby, as per our founding principles and non-profit status.
 * No. There are plenty of other organizations (like FSFE) that focus on persuading organizations that haven't decided to use open source to do so. That isn't part of [our mission](https://about.publiccode.net/organization/mission.html).
 
-Where does your money come from?
+How are you funded?
 
-* The runway was provided by a philanthropic grant, but long term the members of the association (which must be wholly publicly owned, like cities, provinces or states) pool the money and decide which codebases we should work on. In the long term, we expect we'll be funded by a combination of member dues and philanthropic gifts.
-* We're member-funded, but how to get members for a new association is a chicken and egg problem, so we started with a philanthropic grant.
-* In the future, member dues will pay for our core activities. Our expansion and our research and development may be philanthropically funded - this will allow us to develop new stewardship activities, and design and test new assets before we apply these to core activities, which are effectively taxpayer funded.
+* The runway was provided by a philanthropic grant, with the goal that the members of the association (which must be wholly publicly owned, like cities, provinces or states) pool the money and decide which codebases we should work on. In the long term, we thought we would be funded by a combination of member dues and philanthropic gifts.
+* After we complete the transition to a global international organization with local chapters, we expect our funds will come from a combination of structural funding by provincial, national or supranational governments (to multiply stewardship work with our partners), grants from structural philanthropic sources, and individual philanthropic gifts.
+
+What about donor influence - do you have a conflict of interest?
+
+* No. We accept philanthropic donations, but only members (publicly owned organizations) can vote in the general assembly or appoint the board of directors.
+* No. We also don't work for hire; you can't pay the Foundation to do work.
 
 Is now the right time and place? What about incumbent vendors?
 

--- a/activities/communication/pitching.md
+++ b/activities/communication/pitching.md
@@ -95,7 +95,7 @@ What's currently happening with the Foundation?
 
     Our mission, expertise and core activities (codebase stewardship, capability building in public organizations) have not changed. Exactly what each local chapter will focus on will depend on local needs and opportunities, as will their funding model. We already have a North America chapter, and plan one in Europe.
 
-    We hope the transition will be complete by the end of 2023. We'd love your advice on how we can make this successful. 
+    We hope the transition will be complete by the end of 2023. We'd love your advice on how we can make this successful.
 
 Are you a lobbying org? Are you the same as the FSFE?
 

--- a/activities/communication/pitching.md
+++ b/activities/communication/pitching.md
@@ -91,7 +91,7 @@ These are follow up questions we've received, and answers staff have given.
 
 What's currently happening with the Foundation?
 
-* We're in the middle of changing our legal form to become a global umbrella organization with local chapters. We will no longer have public organizations as association members because this was too difficult for most interested organizations; instead, we plan to work with public organizations as partners. 
+* We're in the middle of changing our legal form to become a global umbrella organization with local chapters. We will no longer have public organizations as association members because this was too difficult for most interested organizations; instead, we plan to work with public organizations as partners.
 
     Our mission, expertise and core activities (codebase stewardship, capability building in public organizations) have not changed. Exactly what each local chapter will focus on will depend on local needs and opportunities, as will their funding model. We already have a North America chapter, and plan one in Europe.
 

--- a/activities/communication/pitching.md
+++ b/activities/communication/pitching.md
@@ -62,7 +62,7 @@ We have different perspectives on open source:
 We should reflect our [founding principles](https://about.publiccode.net/organization/mission.html#founding-principles) in our pitches.
 
 Avoid: "we think or we believe" [open source is better].
-Instead, describe what we do: "we help public organizations [share collaborative software].
+Instead, describe what we do: "we help municipalities" [share collaborative software].
 
 ### Contextual knowledge
 

--- a/activities/communication/pitching.md
+++ b/activities/communication/pitching.md
@@ -157,3 +157,8 @@ These are the audiences we've spoken to about the Foundation for Public Code:
 * activists
 * philanthropists
 * the general public
+
+## Further reading
+
+* [Pitching to OSPOs](https://publiccode.net/OSPO)
+* [Explaining codebase stewardship](../explaining-codebase-stewardship)

--- a/activities/communication/pitching.md
+++ b/activities/communication/pitching.md
@@ -30,6 +30,7 @@ For people with government experience or interest:
 For the general public, assuming no prior technology or government experience:
 
 * "Today, municipalities and government agencies have small pieces of software to provide services, and every municipality has their own. But rather than contracting to consulting companies to build their version, municipalities could pool together and make an open source one. Then each municipality only has to customise it to what they need. We help municipalities work together."
+
 * "We help cities build and maintain public purpose, open source software together."
 
 For cocktail party audiences, assuming no interest at all:


### PR DESCRIPTION
We've updated our pitching page to reflect our current roadmap and intentions. This doesn't yet include an elevator pitch for codebase stewardship for public code (for niche/OSPO audiences), but that's a logical addition.