### PR TITLE
remove emoticon from 404 title

### DIFF
--- a/404.md
+++ b/404.md
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: CC0-1.0
 # SPDX-FileCopyrightText: 2022-2023 The Foundation for Public Code <info@publiccode.net>
 layout: default
-title: Page not found :(
+title: Page not found
 toc: false
 ---
 


### PR DESCRIPTION
Attempts to be cute in error messages can backfire and be off-putting, especially if the error is ours